### PR TITLE
ci: add workflow for archiving branches of closed PRs

### DIFF
--- a/.github/workflows/auto-archive.yaml
+++ b/.github/workflows/auto-archive.yaml
@@ -21,9 +21,6 @@ jobs:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
           if [ "$BRANCH_NAME" = "$DEFAULT_BRANCH" ] || [[ "$BRANCH_NAME" == archived/* ]]; then
             echo "⏭️ Skipping: Branch is default branch or already archived"
             exit 0


### PR DESCRIPTION
When any PR is closed, the associated branch is then archived by
renaming it to 'archived/{original_name}'