### PR TITLE
ci: add workflow for archiving branches of closed PRs

### DIFF
--- a/.github/workflows/auto-archive.yaml
+++ b/.github/workflows/auto-archive.yaml
@@ -30,13 +30,14 @@ jobs:
             exit 0
           fi
 
-          NEW_BRANCH_NAME="archived/$BRANCH_NAME"
+          TAG_NAME="archived/$BRANCH_NAME"
 
-          echo "📦 Archiving branch: $BRANCH_NAME -> $NEW_BRANCH_NAME"
+          echo "🏷️ Archiving branch: $BRANCH_NAME -> tag $TAG_NAME"
 
           git fetch origin "$BRANCH_NAME"
-          git branch "$NEW_BRANCH_NAME" "origin/$BRANCH_NAME"
-          git push origin "$NEW_BRANCH_NAME"
+          git tag "$TAG_NAME" "origin/$BRANCH_NAME"
+          git push origin "$TAG_NAME"
           git push origin --delete "$BRANCH_NAME"
 
-          echo "✅ Successfully archived branch to $NEW_BRANCH_NAME"
+          echo "✅ Successfully archived branch as tag $TAG_NAME"
+


### PR DESCRIPTION
Branches of closed PRs will now be archived by tagging them instead of renaming the branch
to 'archived/{branch_name}'