### PR TITLE
ci: add concurrency to pr checks to cancel on new commits

### DIFF
--- a/.github/workflows/proctor-pr.yaml
+++ b/.github/workflows/proctor-pr.yaml
@@ -20,6 +20,10 @@ permissions:
   checks: write
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-proctor:
     name: 🏗️ Build Proctor

--- a/.github/workflows/sentintel-pr.yaml
+++ b/.github/workflows/sentintel-pr.yaml
@@ -20,6 +20,10 @@ permissions:
   checks: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-sentinel:
     name: 🏗️ Build Sentinel

--- a/.github/workflows/server-pr.yaml
+++ b/.github/workflows/server-pr.yaml
@@ -20,6 +20,10 @@ permissions:
   checks: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-server:
     name: 🏗️ Build Server


### PR DESCRIPTION
Cancels previous PR-Check runs if new commits are pushed
to not waste resources.