### PR TITLE
fix: make javascript executable in browser

### DIFF
--- a/hugo/docker/nginx.conf
+++ b/hugo/docker/nginx.conf
@@ -6,7 +6,6 @@ server {
         try_files $uri $uri/ =404;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; object-src 'none';" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
     }
 }

--- a/proctor/docker/nginx.conf
+++ b/proctor/docker/nginx.conf
@@ -11,7 +11,6 @@ server {
         try_files $uri $uri/ /proctor/index.html;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Content-Security-Policy "default-src 'self';" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
     }
 }


### PR DESCRIPTION
Changes in the nginx.config files of hugo and proctor, so that javascript can run in the browser.

Closes: #73 