### PR TITLE
fix(sentinel): set RSV to 0 in websocket frames

### DIFF
--- a/sentinel/src/ws.rs
+++ b/sentinel/src/ws.rs
@@ -84,7 +84,8 @@ pub fn connect_to_server_sync() {
                 };
                 first = false;
 
-                let df = DataFrame::new(finished, opcode, payload[offset..end].to_vec());
+                let mut df = DataFrame::new(finished, opcode, payload[offset..end].to_vec());
+                df.reserved = [false, false, false];
                 let _ = client.send_dataframe(&df);
                 offset = end;
             }


### PR DESCRIPTION
## Description

This pull request fixes a connection issue where the server abruptly closes the WebSocket connection with a CorruptedWebSocketFrameException.

## Changes

ws.rs: Modified the WebSocket frame construction loop to explicitly set the reserved bits to false (0) for all data frames.

## Additional Information

Closes: #106

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Tests passed
