### PR TITLE
FIX: use fake frame generation for macos

### DIFF
--- a/sentinel/src/lib.rs
+++ b/sentinel/src/lib.rs
@@ -6,7 +6,7 @@ use crate::screen_capture::RecordControlMessage;
 
 pub mod ws;
 
-#[cfg(env = "dev")]
+#[cfg(any(env = "dev", target_os = "macos"))]
 mod image_generator;
 
 mod screen_capture;

--- a/sentinel/src/screen_capture.rs
+++ b/sentinel/src/screen_capture.rs
@@ -1,20 +1,23 @@
-use std::{
-    process::exit,
-    sync::{OnceLock, mpsc},
-};
+use std::sync::OnceLock;
+#[cfg(not(target_os = "macos"))]
+use std::{process::exit, sync::mpsc};
 
 use base64::Engine;
 use tokio::sync::{
     RwLock,
     mpsc::{Receiver, Sender},
 };
-use tracing::{debug, error, warn};
+#[cfg(not(target_os = "macos"))]
+use tracing::error;
+use tracing::{debug, warn};
 use xcap::{
-    Frame, Monitor, VideoRecorder,
+    Frame,
     image::{ExtendedColorType, ImageEncoder, codecs::png::PngEncoder},
 };
+#[cfg(not(target_os = "macos"))]
+use xcap::{Monitor, VideoRecorder};
 
-#[cfg(env = "dev")]
+#[cfg(any(env = "dev", target_os = "macos"))]
 static GENERATE_FRAME_WIDTH: usize = 192;
 
 #[derive(Debug, Clone)]
@@ -37,50 +40,56 @@ pub(crate) async fn start_screen_recording(
     mut ctrl_rx: Receiver<RecordControlMessage>,
     frame_tx: Sender<FrameResponse>,
 ) {
-    let monitor = Monitor::from_point(100, 100).unwrap();
-
+    #[cfg(not(target_os = "macos"))]
     let mut video_recorder: Option<VideoRecorder> = None;
-    let sx: mpsc::Receiver<Frame>;
 
-    let mut failed_screen_grab_attempts = 0;
+    #[cfg(not(target_os = "macos"))]
+    {
+        let monitor = Monitor::from_point(100, 100).unwrap();
+        let sx: mpsc::Receiver<Frame>;
+        let mut failed_screen_grab_attempts = 0;
 
-    loop {
-        let res = monitor.video_recorder();
+        loop {
+            let res = monitor.video_recorder();
 
-        if let Ok((vr, s)) = res {
-            debug!("got video recorder");
-            video_recorder = Some(vr);
-            sx = s;
-            tokio::spawn(async move {
-                loop {
-                    match sx.recv() {
-                        Ok(frame) => {
-                            // if not initialized
-                            if let Some(lock_rwl) = GLOBAL_FRAME.get() {
-                                let mut lock = lock_rwl.write().await;
-                                *lock = frame;
-                            } else {
-                                GLOBAL_FRAME.set(RwLock::new(frame)).unwrap();
+            if let Ok((vr, s)) = res {
+                debug!("got video recorder");
+                video_recorder = Some(vr);
+                sx = s;
+                tokio::spawn(async move {
+                    loop {
+                        match sx.recv() {
+                            Ok(frame) => {
+                                // if not initialized
+                                if let Some(lock_rwl) = GLOBAL_FRAME.get() {
+                                    let mut lock = lock_rwl.write().await;
+                                    *lock = frame;
+                                } else {
+                                    GLOBAL_FRAME.set(RwLock::new(frame)).unwrap();
+                                }
                             }
+                            _ => continue,
                         }
-                        _ => continue,
                     }
-                }
-            });
-            break;
-        }
-
-        failed_screen_grab_attempts += 1;
-        if failed_screen_grab_attempts >= 2 {
-            if cfg!(env = "prod") {
-                error!("video recorder in None! exiting...");
-                exit(1);
-            } else {
-                warn!("failed to get video recorder! Using fake frames.");
+                });
+                break;
             }
-            break;
+
+            failed_screen_grab_attempts += 1;
+            if failed_screen_grab_attempts >= 2 {
+                if cfg!(env = "prod") {
+                    error!("video recorder in None! exiting...");
+                    exit(1);
+                } else {
+                    warn!("failed to get video recorder! Using fake frames.");
+                }
+                break;
+            }
         }
     }
+
+    #[cfg(target_os = "macos")]
+    warn!("macOS detected: skipping video recorder, using fake frames.");
 
     loop {
         if let Some(ctrl_message) = ctrl_rx.recv().await {
@@ -91,13 +100,13 @@ pub(crate) async fn start_screen_recording(
                     if let Some(frame_rwl) = GLOBAL_FRAME.get() {
                         frame = Some(frame_rwl.read().await.clone());
                     } else {
-                        #[cfg(env = "dev")]
+                        #[cfg(any(env = "dev", target_os = "macos"))]
                         {
                             use crate::image_generator::generate_random_image;
                             let data = generate_random_image(GENERATE_FRAME_WIDTH);
                             frame = Some(Frame::new(data.0 as u32, data.1 as u32, data.2))
                         }
-                        #[cfg(env = "prod")]
+                        #[cfg(all(env = "prod", not(target_os = "macos")))]
                         {
                             frame = None;
                         }
@@ -118,12 +127,14 @@ pub(crate) async fn start_screen_recording(
                 }
                 RecordControlMessage::StopRecording => {
                     debug!("stop recording");
+                    #[cfg(not(target_os = "macos"))]
                     if let Some(vr) = video_recorder.as_ref() {
                         let _ = vr.stop();
                     }
                 }
                 RecordControlMessage::StartRecording => {
                     debug!("start recording");
+                    #[cfg(not(target_os = "macos"))]
                     if let Some(vr) = video_recorder.as_ref() {
                         let _ = vr.start();
                     }


### PR DESCRIPTION
Rust uses a different VideoRecorder on MacOS that is not Send so it fails with async.
For now we just disable screen recording on MacOS and only use fake frames.
MacOS screen recording will be implemented at a later stage when it's needed and everything works fine on linux.

## Description

This PR adds compillation gurads arround the video recorder for macos on `prod` and `dev` profiles and instead of recording, generates fake frames.

## Changes

add `target_os = "macos"` to video recorder related stuff and enable fake frame generation for macos.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Tests passed
