### PR TITLE
WIP: Project coverage will be checked on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,8 +9,8 @@ flags:
   server:
     carryforward: true
 
-  proctor:
-    carryforward: true
+  # proctor:
+  #   carryforward: true
 
 
 coverage:
@@ -20,31 +20,35 @@ coverage:
 
   status:
     default_rules:
-      flag_coverage_not_uploaded_behavior: exclude
+      flag_coverage_not_uploaded_behavior: pass
 
     project:
       default:
         target: 20%
         threshold: 0%
-        informational: false
+        informational: true
+        flags: 
+          - server
+          - sentinel
+          # - proctor
 
       sentinel:
         flags: [sentinel]
         target: 40%
         threshold: 0%
-        informational: false
+        informational: true
 
       server:
         flags: [server]
         target: 10%
         threshold: 0%
-        informational: false
+        informational: true
 
-      proctor:
-        flags: [proctor]
-        target: 0%
-        threshold: 0%
-        informational: false
+      # proctor:
+      #   flags: [proctor]
+      #   target: 0%
+      #   threshold: 0%
+      #   informational: false
 
     patch:
       default:


### PR DESCRIPTION
## Description

This PR makes codecov pass missing flags on pr checks and use the carry forward so project coverage runs too.

This makes it so when only sentinel is updated but not server, the server carries the last coverage of server forward.

## Changes

- update `codecov.yml` to not include proctor anymore and pass missing flags

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Tests passed
