### PR TITLE
fix: revoke subscription from sentinel when viewing other sentinel

### DIFF
--- a/proctor/src/stores/WebsocketStore.ts
+++ b/proctor/src/stores/WebsocketStore.ts
@@ -50,7 +50,7 @@ export const useWebsocketStore = defineStore("websocketStore", () => {
     console.log("Subscribing to sentinel", sentinelId)
      if (subscribedSentinel.value !== null) {
        sendMessage({
-         type: "proctor.unsubscribe",
+         type: "proctor.revoke-subscription",
          payload: {
            sentinelId: subscribedSentinel.value
          },

--- a/proctor/src/types/WebsocketPayloads.ts
+++ b/proctor/src/types/WebsocketPayloads.ts
@@ -13,7 +13,7 @@ export interface RegisterMessage {
 }
 
 export interface SentinelIdMessage {
-  type: "proctor.subscribe" | "proctor.unsubscribe"
+  type: "proctor.subscribe" | "proctor.revoke-subscription"
   payload: {
     sentinelId: string
   }


### PR DESCRIPTION
## Description

Fixes bug where proctor would continue to receive frames from previous selected sentinels after switching to a new one.

## Changes

- Changed type for SentinelIdMessage

## Additional Information

Fixes #124 

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Tests passed
