### PR TITLE
fix(server): make server accept 10mb websocket messages

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -22,6 +22,9 @@ quarkus.http.port=5050
 # Disable built-in compression
 quarkus.http.enable-compression=false
 
+# Allow messages up to 10mb
+quarkus.websocket.max-frame-size=10485760
+
 # Quarkus tests should not fail if 8081 is taken (e.g. parallel Maven runs)
 %test.quarkus.http.test-port=0
 %test.quarkus.http.test-ssl-port=0


### PR DESCRIPTION
## Description

This PR actually should fix the long going issue where the sentinel sends larger than 64 kb frames which the server doesn't want to handle.

## Changes

Set accepted websocket frame size to 10 mb.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Tests passed
