### PR TITLE
fix(sentinel): fix thirdparty licenses build failing

### DIFF
--- a/sentinel/default.nix
+++ b/sentinel/default.nix
@@ -11,6 +11,7 @@
     ...
   }: let
     licenseFile = pkgs.writeText "LICENSE" project-license-text;
+    versionFile = pkgs.writeText "VERSION" project-version;
 
     scripts = [
       (pkgs.writeScriptBin "fr-sentinel-pr-check" ''
@@ -103,6 +104,7 @@
 
       LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
       LICENSE_PATH = "${licenseFile}";
+      VERSION_PATH = "${versionFile}";
 
       buildFeatures = [
         "prod"

--- a/sentinel/src/build.rs
+++ b/sentinel/src/build.rs
@@ -32,58 +32,48 @@ struct LicenseText {
 
 fn bundle_licenses() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let out_path = Path::new(&manifest_dir).join("thirdparty");
 
-    fs::create_dir_all(&out_path).expect("failed to create thirdparty/ directory");
-
-    let yaml_path = out_path.join("licenses.yaml");
-    let status = Command::new("cargo")
-        .args([
-            "bundle-licenses",
-            "-f",
-            "yaml",
-            "-o",
-            yaml_path
-                .to_str()
-                .expect("thirdparty path is not valid UTF-8"),
-        ])
-        .status()
+    let output = Command::new("cargo")
+        .args(["bundle-licenses", "-f", "yaml", "-o", "/dev/stdout"])
+        .output()
         .expect("failed to run cargo bundle-licenses — is it installed?");
 
     assert!(
-        status.success(),
-        "cargo bundle-licenses failed with exit code: {status}"
+        output.status.success(),
+        "cargo bundle-licenses failed with exit code: {}",
+        output.status
     );
 
-    let license_src = match env::var("LICENSE_PATH") {
-        Ok(path) => PathBuf::from(path),
-        Err(_) => Path::new(&manifest_dir).join("../LICENSE"),
-    };
-    let license_dst = out_path.join("LICENSE");
-    fs::copy(&license_src, &license_dst).unwrap_or_else(|e| {
-        panic!(
-            "failed to copy LICENSE from {} to {}: {e}",
-            license_src.display(),
-            license_dst.display()
-        )
-    });
+    let license_src = env::var("LICENSE_PATH").map_or_else(
+        |_| Path::new(&manifest_dir).join("../LICENSE"),
+        PathBuf::from,
+    );
 
-    let yaml_content = fs::read_to_string(&yaml_path).expect("failed to read licenses.yaml");
+    let license_content = read_to_string(license_src).expect("license couldn't be read!");
+
+    let yaml_content =
+        String::from_utf8(output.stdout).expect("bundle-licenses was not valid UTF-8 output");
     let bundled: BundledLicenses =
         serde_yaml_ng::from_str(&yaml_content).expect("failed to parse licenses.yaml");
 
     let libs = &bundled.third_party_libraries;
 
-    let short = generate_short(libs);
-    fs::write(out_path.join("licenses-short.txt"), short)
-        .expect("failed to write licenses-short.txt");
+    let short_content = generate_short(libs);
 
-    let full = generate_full(libs);
-    fs::write(out_path.join("licenses-full.txt"), full).expect("failed to write licenses-full.txt");
+    let full_content = generate_full(libs);
+
+    let out_dir = env::var("OUT_DIR").expect("NO OUT_DIR VARIABLE");
+    let out = std::path::Path::new(&out_dir);
 
     println!("cargo:rerun-if-changed=Cargo.lock");
-    println!("cargo:rerun-if-changed={}", license_src.display());
     println!("cargo:rerun-if-env-changed=LICENSE_PATH");
+
+    fs::write(out.join("PROJECT_LICENSE.txt"), license_content)
+        .expect("Failed to write PROJECT_LICENSE");
+    fs::write(out.join("THIRDPARTY_SHORT.txt"), short_content)
+        .expect("Failed to write THIRDPARTY_SHORT");
+    fs::write(out.join("THIRDPARTY_FULL.txt"), full_content)
+        .expect("Failed to write THIRDPARTY_FULL");
 }
 
 fn generate_short(libs: &[Library]) -> String {
@@ -152,7 +142,14 @@ fn generate_full(libs: &[Library]) -> String {
 }
 
 fn set_env_cfg() {
-    let franklyn_version = read_to_string("../VERSION")
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+
+    let version_src = env::var("VERSION_PATH").map_or_else(
+        |_| Path::new(&manifest_dir).join("../VERSION"),
+        PathBuf::from,
+    );
+
+    let franklyn_version = read_to_string(version_src)
         .expect("VERSION file doesn't exist!")
         .replace(['\n', '\r'], "");
 

--- a/sentinel/src/lib.rs
+++ b/sentinel/src/lib.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, ValueEnum, arg};
 use screen_capture::FrameResponse;
 use tokio::sync::mpsc;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::screen_capture::RecordControlMessage;
 

--- a/sentinel/src/main.rs
+++ b/sentinel/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process;
@@ -15,9 +16,9 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-const PROJECT_LICENSE: &str = include_str!("../thirdparty/LICENSE");
-const THIRDPARTY_SHORT: &str = include_str!("../thirdparty/licenses-short.txt");
-const THIRDPARTY_FULL: &str = include_str!("../thirdparty/licenses-full.txt");
+const PROJECT_LICENSE: &str = include_str!(concat!(env!("OUT_DIR"), "/PROJECT_LICENSE.txt"));
+const THIRDPARTY_SHORT: &str = include_str!(concat!(env!("OUT_DIR"), "/THIRDPARTY_SHORT.txt"));
+const THIRDPARTY_FULL: &str = include_str!(concat!(env!("OUT_DIR"), "/THIRDPARTY_FULL.txt"));
 
 #[tokio::main]
 async fn main() {

--- a/sentinel/src/oidc.rs
+++ b/sentinel/src/oidc.rs
@@ -13,7 +13,7 @@ use openidconnect::{
     AuthorizationCode, ClientId, CsrfToken, IssuerUrl, Nonce, PkceCodeChallenge, RedirectUrl, Scope,
 };
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::error;
 use url::Url;
 
 use crate::config::CONFIG;

--- a/sentinel/src/ws.rs
+++ b/sentinel/src/ws.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -10,11 +9,9 @@ use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::interval;
+use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::handshake::client::generate_key;
-use tokio_tungstenite::tungstenite::http::Uri;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
-use tokio_tungstenite::tungstenite::{Message, http};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;


### PR DESCRIPTION
## Summary

This PR fixes a bug where the nix build failed because of a permission error while trying to bundle thirdparty licenses and writing to an output path.

During the build process, the sentinel doesn't write to a `thirdparty/` directory anymore but rather writes directly into the output directory of the cargo build.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [X] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [X] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
