### PR TITLE
fix: naming conventions change for aur

### DIFF
--- a/scripts/aur-deploy.sh
+++ b/scripts/aur-deploy.sh
@@ -150,6 +150,7 @@ update_aur() {
 
   # Update version in PKGBUILD
   sed -i "s/^pkgver=.*/pkgver=${PKGVER}/" PKGBUILD
+  sed -i "s/^_pkgver_orig=.*/_pkgver_orig=${VERSION}/" PKGBUILD
   sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 
   # Calculate and update checksums if binaries provided
@@ -176,6 +177,11 @@ update_aur() {
     cp "${AUR_DIR}/${PKG_NAME}/.SRCINFO" .
     sed -i "s/pkgver = .*/pkgver = ${PKGVER}/" .SRCINFO
     sed -i "s/pkgrel = .*/pkgrel = 1/" .SRCINFO
+    # Update source URLs with original version (containing + for download URLs)
+    sed -i "s|franklyn-sentinel-0.0.0|franklyn-sentinel-${VERSION}|g" .SRCINFO
+    # Update the local filename reference to use sanitized pkgver
+    sed -i "s|franklyn-sentinel-${VERSION}-x86_64::|franklyn-sentinel-${PKGVER}-x86_64::|g" .SRCINFO
+    sed -i "s|franklyn-sentinel-${VERSION}-aarch64::|franklyn-sentinel-${PKGVER}-aarch64::|g" .SRCINFO
   fi
 
   echo "=== Committing changes ==="

--- a/sentinel/aur/franklyn-bin-dev/PKGBUILD
+++ b/sentinel/aur/franklyn-bin-dev/PKGBUILD
@@ -4,6 +4,7 @@
 pkgname=franklyn-bin-dev
 _pkgname=franklyn-sentinel
 pkgver=0.0.0
+_pkgver_orig=0.0.0  # Original version with + for download URLs (AUR doesn't allow + in pkgver)
 pkgrel=1
 pkgdesc="Screen monitoring client for Franklyn (development channel) - streams student screen activity to teacher dashboard during exams"
 arch=('x86_64' 'aarch64')
@@ -16,10 +17,10 @@ options=('!strip')
 
 _base_url="https://github.com/2526-4ahitm-itp/2526-4ahitm-franklyn/releases/download"
 
-source_x86_64=("${_pkgname}-${pkgver}-x86_64::${_base_url}/v${pkgver}/${_pkgname}-${pkgver}-x86_64-linux"
+source_x86_64=("${_pkgname}-${pkgver}-x86_64::${_base_url}/v${_pkgver_orig}/${_pkgname}-${_pkgver_orig}-x86_64-linux"
                "franklyn-sentinel.desktop"
                "LICENSE::https://raw.githubusercontent.com/2526-4ahitm-itp/2526-4ahitm-franklyn/main/LICENSE")
-source_aarch64=("${_pkgname}-${pkgver}-aarch64::${_base_url}/v${pkgver}/${_pkgname}-${pkgver}-aarch64-linux"
+source_aarch64=("${_pkgname}-${pkgver}-aarch64::${_base_url}/v${_pkgver_orig}/${_pkgname}-${_pkgver_orig}-aarch64-linux"
                 "franklyn-sentinel.desktop"
                 "LICENSE::https://raw.githubusercontent.com/2526-4ahitm-itp/2526-4ahitm-franklyn/main/LICENSE")
 

--- a/sentinel/aur/franklyn-bin/PKGBUILD
+++ b/sentinel/aur/franklyn-bin/PKGBUILD
@@ -4,6 +4,7 @@
 pkgname=franklyn-bin
 _pkgname=franklyn-sentinel
 pkgver=0.0.0
+_pkgver_orig=0.0.0  # Original version with + for download URLs (AUR doesn't allow + in pkgver)
 pkgrel=1
 pkgdesc="Screen monitoring client for Franklyn - streams student screen activity to teacher dashboard during exams"
 arch=('x86_64' 'aarch64')
@@ -16,10 +17,10 @@ options=('!strip')
 
 _base_url="https://github.com/2526-4ahitm-itp/2526-4ahitm-franklyn/releases/download"
 
-source_x86_64=("${_pkgname}-${pkgver}-x86_64::${_base_url}/v${pkgver}/${_pkgname}-${pkgver}-x86_64-linux"
+source_x86_64=("${_pkgname}-${pkgver}-x86_64::${_base_url}/v${_pkgver_orig}/${_pkgname}-${_pkgver_orig}-x86_64-linux"
                "franklyn-sentinel.desktop"
                "LICENSE::https://raw.githubusercontent.com/2526-4ahitm-itp/2526-4ahitm-franklyn/main/LICENSE")
-source_aarch64=("${_pkgname}-${pkgver}-aarch64::${_base_url}/v${pkgver}/${_pkgname}-${pkgver}-aarch64-linux"
+source_aarch64=("${_pkgname}-${pkgver}-aarch64::${_base_url}/v${_pkgver_orig}/${_pkgname}-${_pkgver_orig}-aarch64-linux"
                 "franklyn-sentinel.desktop"
                 "LICENSE::https://raw.githubusercontent.com/2526-4ahitm-itp/2526-4ahitm-franklyn/main/LICENSE")
 


### PR DESCRIPTION
## Summary

AUR doesnt like +, so it wont get any anymore

Fixes #AUR Deployment

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
