### PR TITLE
fix: script now updates .srcinfo

### DIFF
--- a/scripts/aur-deploy.sh
+++ b/scripts/aur-deploy.sh
@@ -173,15 +173,10 @@ update_aur() {
   if command -v makepkg &> /dev/null; then
     makepkg --printsrcinfo > .SRCINFO
   else
-    # Manual .SRCINFO update (for CI environments without makepkg)
     cp "${AUR_DIR}/${PKG_NAME}/.SRCINFO" .
-    sed -i "s/pkgver = .*/pkgver = ${PKGVER}/" .SRCINFO
-    sed -i "s/pkgrel = .*/pkgrel = 1/" .SRCINFO
-    # Update source URLs with original version (containing + for download URLs)
-    sed -i "s|franklyn-sentinel-0.0.0|franklyn-sentinel-${VERSION}|g" .SRCINFO
-    # Update the local filename reference to use sanitized pkgver
-    sed -i "s|franklyn-sentinel-${VERSION}-x86_64::|franklyn-sentinel-${PKGVER}-x86_64::|g" .SRCINFO
-    sed -i "s|franklyn-sentinel-${VERSION}-aarch64::|franklyn-sentinel-${PKGVER}-aarch64::|g" .SRCINFO
+    sed -i "s|pkgver = .*|pkgver = ${PKGVER}|" .SRCINFO   sed -i "s|pkgrel = .*|pkgrel = 1|" .SRCINFO   
+    sed -i "s|franklyn-sentinel-[0-9.]*|franklyn-sentinel-${VERSION}|g" .SRCINFO   
+    sed -i "s|releases/download/v[0-9.]*/|releases/download/v${VERSION}/|g" .SRCINFO
   fi
 
   echo "=== Committing changes ==="


### PR DESCRIPTION
## Summary

The links of the deploy script now update automatically, without manual labor

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
