### PR TITLE
fix(sentinel): include the current version in the licenses text

### DIFF
--- a/sentinel/src/main.rs
+++ b/sentinel/src/main.rs
@@ -122,8 +122,7 @@ fn get_user_log_dir() -> PathBuf {
 
 fn format_header() -> String {
     format!(
-        "franklyn-sentinel v{}\n\n{PROJECT_LICENSE}\n{}",
-        env!("CARGO_PKG_VERSION"),
+        "franklyn-sentinel v{VERSION}\n\n{PROJECT_LICENSE}\n{}",
         "=".repeat(80)
     )
 }


### PR DESCRIPTION
## Summary

The actual VERSION is not included in the versions string when using `--licenses` or `--licenses-full` which was `v0.0.0` previously.

Fixes #

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
