### PR TITLE
fix/ command in aur deployment now seperated

### DIFF
--- a/scripts/aur-deploy.sh
+++ b/scripts/aur-deploy.sh
@@ -174,8 +174,9 @@ update_aur() {
     makepkg --printsrcinfo > .SRCINFO
   else
     cp "${AUR_DIR}/${PKG_NAME}/.SRCINFO" .
-    sed -i "s|pkgver = .*|pkgver = ${PKGVER}|" .SRCINFO   sed -i "s|pkgrel = .*|pkgrel = 1|" .SRCINFO   
-    sed -i "s|franklyn-sentinel-[0-9.]*|franklyn-sentinel-${VERSION}|g" .SRCINFO   
+    sed -i "s|pkgver = .*|pkgver = ${PKGVER}|" .SRCINFO
+    sed -i "s|pkgrel = .*|pkgrel = 1|" .SRCINFO
+    sed -i "s|franklyn-sentinel-[0-9.]*|franklyn-sentinel-${VERSION}|g" .SRCINFO
     sed -i "s|releases/download/v[0-9.]*/|releases/download/v${VERSION}/|g" .SRCINFO
   fi
 


### PR DESCRIPTION
## Summary

The sed commands in the aur deployment, arent seperated and get called together

Fixes #AUR :pray: 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
