### PR TITLE
perf/ boost server performance

### DIFF
--- a/server/src/main/java/at/ac/htlleonding/franklynserver/cache/Cache.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/cache/Cache.java
@@ -4,11 +4,11 @@ import at.ac.htlleonding.franklynserver.model.Frame;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @ApplicationScoped
 public class Cache {
@@ -16,7 +16,7 @@ public class Cache {
     int frameDuration;
 
     Map<UUID, Frame> frameMap = new ConcurrentHashMap<>();
-    List<FrameListener> frameListeners = new CopyOnWriteArrayList<>();
+    Map<UUID, Set<FrameListener>> frameListeners = new ConcurrentHashMap<>();
 
     // When the Frame class is implemented use Frame frame instead of String jsonFrame
 
@@ -30,9 +30,10 @@ public class Cache {
     public void saveFrame(Frame frame, UUID sentinelId) {
         frameMap.put(sentinelId, frame);
 
-        frameListeners.stream()
-                .filter(listener -> listener.sentinelId().equals(sentinelId))
-                .forEach(listener -> listener.frameConsumer().accept(frame));
+        Set<FrameListener> listeners = frameListeners.get(sentinelId);
+        if (listeners != null) {
+            listeners.forEach(listener -> listener.frameConsumer().accept(frame));
+        }
     }
 
     public Optional<Frame> getFrame(UUID sentinelId) {
@@ -40,10 +41,14 @@ public class Cache {
     }
 
     public void registerOnFrame(FrameListener frameListener) {
-        frameListeners.add(frameListener);
+        frameListeners.computeIfAbsent(frameListener.sentinelId(), k -> ConcurrentHashMap.newKeySet())
+                .add(frameListener);
     }
 
     public void unregisterOnFrame(FrameListener frameListener) {
-        frameListeners.remove(frameListener);
+        Set<FrameListener> listeners = frameListeners.get(frameListener.sentinelId());
+        if (listeners != null) {
+            listeners.remove(frameListener);
+        }
     }
 }

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/websocket/FranklynWebSocketServer.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/websocket/FranklynWebSocketServer.java
@@ -36,6 +36,7 @@ public class FranklynWebSocketServer {
     private final Map<String, WebSocketConnection> proctorConnections = new ConcurrentHashMap<>();
 
     private final Map<String, Set<FrameListener>> proctorListeners = new ConcurrentHashMap<>();
+    private final Map<WebSocketConnection, String> proctorSentinelReverse = new ConcurrentHashMap<>();
 
     // New Connection
     @OnOpen
@@ -116,6 +117,7 @@ public class FranklynWebSocketServer {
 
                     frameCache.registerOnFrame(listener);
                     proctorListeners.computeIfAbsent(proctorId, k -> ConcurrentHashMap.newKeySet()).add(listener);
+                    proctorSentinelReverse.put(connection, sentinelIdToSubscribe);
                 }
                 break;
 
@@ -134,6 +136,7 @@ public class FranklynWebSocketServer {
                             return false;
                         });
                     }
+                    proctorSentinelReverse.remove(connection);
                 }
                 break;
 
@@ -183,6 +186,7 @@ public class FranklynWebSocketServer {
         if (listeners != null) {
             listeners.forEach(frameCache::unregisterOnFrame);
         }
+        proctorSentinelReverse.remove(connection);
 
         // Cleanup Sentinels
         sentinelConnections.entrySet().removeIf(entry -> {


### PR DESCRIPTION
## Summary

Make the Cache thread safe, and adjust code to be O(1) linear time instead of O(n)

Fixes #182 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [x] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [x] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
