### PR TITLE
DOCS: Implement the Pins into the websocket comms protocol

### DIFF
--- a/hugo/content/docs/reference/websocket-comm/lifecycle.md
+++ b/hugo/content/docs/reference/websocket-comm/lifecycle.md
@@ -14,8 +14,9 @@ This document describes the lifecycle of WebSocket connections for both Sentinel
 ### Flow
 
 1. Connect to server via WebSocket with `Authorization: Bearer <jwt>` header
-2. Send `sentinel.register` as the first message
+2. Send `sentinel.register` as the first message with PIN code (1337-4200)
 3. Receive `server.registration.ack` or `server.registration.reject`
+   - If rejected due to invalid PIN, the reason will be "Invalid PIN"
 4. If accepted: receive `server.set-resolution` when the server updates the
    capture resolution
 5. Send `sentinel.frame` every couple of seconds
@@ -35,11 +36,11 @@ S -> Srv : WebSocket connect
 activate Srv
 
 == Registration ==
-S -> Srv : sentinel.register
+S -> Srv : sentinel.register (with PIN)
 alt registration accepted
   Srv -> S : server.registration.ack
 else registration rejected
-  Srv -> S : server.registration.reject
+  Srv -> S : server.registration.reject (Invalid PIN)
   S <-> Srv : connection closed
 end
 
@@ -67,10 +68,11 @@ deactivate Srv
 2. Send `proctor.register` as the first message
 3. Receive `server.registration.ack` or `server.registration.reject`
 4. If accepted:
-   - Receive `server.update-sentinels` with the list of available sentinels
-   - Send `proctor.subscribe` or `proctor.revoke-subscription` as needed
-   - Send `proctor.set-profile` to request `HIGH`, `MEDIUM`, or `LOW`
-   - Receive `server.frame` for subscribed sentinels
+    - Send `proctor.set-pin` to specify which PIN's sentinels to monitor (1337-4200)
+    - Receive `server.update-sentinels` with the list of available sentinels for that PIN
+    - Send `proctor.subscribe` or `proctor.revoke-subscription` as needed
+    - Send `proctor.set-profile` to request `HIGH`, `MEDIUM`, or `LOW`
+    - Receive `server.frame` for subscribed sentinels
 5. Connection closes when the proctor shuts down
 
 ### Sentinel Updates
@@ -79,6 +81,7 @@ The server sends `server.update-sentinels` to the proctor:
 
 - Immediately after successful registration
 - Whenever a sentinel connects or disconnects
+- When the Proctor updates their pin
 
 ### Sequence Diagram
 
@@ -97,26 +100,29 @@ activate Srv
 P -> Srv : proctor.register
 alt registration accepted
   Srv -> P : server.registration.ack
-  Srv -> P : server.update-sentinels
 else registration rejected
   Srv -> P : server.registration.reject
   P <-> Srv : connection closed
 end
 
+== PIN Setting ==
+P -> Srv : proctor.set-pin (with PIN)
+Srv -> P : server.update-sentinels (for PIN)
+
 == Monitoring ==
 
 group Subscription Management [can occur anytime]
-  P -> Srv : proctor.subscribe
-  P -> Srv : proctor.revoke-subscription
-  P -> Srv : proctor.set-profile
+   P -> Srv : proctor.subscribe
+   P -> Srv : proctor.revoke-subscription
+   P -> Srv : proctor.set-profile
 end
 
 loop frames available for subscriptions
-  Srv -> P : server.frame
+   Srv -> P : server.frame
 end
 
 Srv -> P : server.update-sentinels
-note right : sent when sentinels\nconnect or disconnect
+note right : sent when sentinels\nconnect or disconnect\nwith current PIN
 
 == Disconnection ==
 P <-> Srv : connection closed

--- a/hugo/content/docs/reference/websocket-comm/server-proctor.md
+++ b/hugo/content/docs/reference/websocket-comm/server-proctor.md
@@ -42,6 +42,33 @@ Empty payload.
 
 ---
 
+### `proctor.set-pin`
+
+Used to set a PIN for filtering sentinels. The server will only send updates for sentinels
+that registered with this PIN. Setting a new PIN replaces the previous PIN filter.
+
+**Direction:** Proctor -> Server
+
+**Payload:**
+
+| Field | Type   | Required | Description         |
+|-------|--------|----------|---------------------|
+| `pin` | integer| yes      | PIN code (1337-4200)|
+
+**Example:**
+
+```json
+{
+  "type": "proctor.set-pin",
+  "timestamp": 1696969420,
+  "payload": {
+    "pin": 2024
+  }
+}
+```
+
+---
+
 ### `server.registration.ack`
 
 This message will be sent from the server to acknowledge a registration of a proctor.
@@ -97,8 +124,9 @@ If the proctor receives this message, it should close the connection.
 
 ### `server.update-sentinels`
 
-Sends a list of all available sentinels to choose from to the Proctor.
-All sentinels not in this list are assumed to be dead.
+Sends a list of sentinels available for the proctor's currently set PIN.
+Only sentinels that registered with this PIN are included.
+All sentinels not in this list are either dead or registered with a different PIN.
 
 **Direction:** Server -> Proctor
 

--- a/hugo/content/docs/reference/websocket-comm/server-sentinel.md
+++ b/hugo/content/docs/reference/websocket-comm/server-sentinel.md
@@ -27,7 +27,9 @@ This message must be the first message sent or the sentinel will be disconnected
 
 **Payload:**
 
-Empty payload.
+| Field | Type   | Required | Description                    |
+|-------|--------|----------|--------------------------------|
+| `pin` | integer| yes      | PIN code (1337-4200)         |
 
 **Example:**
 
@@ -35,7 +37,9 @@ Empty payload.
 {
   "type": "sentinel.register",
   "timestamp": 1696969420,
-  "payload": {}
+  "payload": {
+    "pin": 2024
+  }
 }
 ```
 
@@ -87,7 +91,7 @@ If the sentinel receives this message, it should close the connection.
   "type": "server.registration.reject",
   "timestamp": 1696969420,
   "payload": {
-    "reason": "Server busy"
+    "reason": "Invalid PIN"
   }
 }
 ```


### PR DESCRIPTION
Sentinels need to send a pin when registering.

Proctors need to set a pin from which they want to receive sentinels.

Closes: #208

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [X] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [X] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
