### PR TITLE
Feat/sentinel pin

### DIFF
--- a/sentinel/src/lib.rs
+++ b/sentinel/src/lib.rs
@@ -38,6 +38,10 @@ pub struct Args {
     /// Run with extra logging
     #[arg(long = "verbose")]
     pub verbose: bool,
+
+    /// 4-digit pin of the test to join
+    #[arg(long = "pin", short)]
+    pub pin: u32,
 }
 
 pub fn debug() {
@@ -58,7 +62,7 @@ pub async fn start(args: Args) {
         }
     };
 
-    ws::connect_to_server_async(recorder, capture_rx, token.access_token).await;
+    ws::connect_to_server_async(recorder, capture_rx, token.access_token, args.pin).await;
 }
 
 mod config {

--- a/sentinel/src/ws.rs
+++ b/sentinel/src/ws.rs
@@ -25,6 +25,7 @@ pub(crate) async fn connect_to_server_async(
     recorder: Recorder,
     mut capture_rx: Receiver<CaptureOutput>,
     jwt: String,
+    pin: u32,
 ) {
     let protocol_prefix = if cfg!(env = "prod") { "wss:" } else { "ws:" };
     let uri_string = format!("{}{}/ws/sentinel", protocol_prefix, CONFIG.api_url);
@@ -73,7 +74,7 @@ pub(crate) async fn connect_to_server_async(
 
     let register_message = SentinelMessage {
         timestamp: Utc::now().timestamp(),
-        payload: SentinelPayload::Register,
+        payload: SentinelPayload::Register { pin },
     };
 
     let payload = serde_json::to_string(&register_message).unwrap();
@@ -200,7 +201,7 @@ pub struct ServerMessage {
 #[serde(tag = "type", content = "payload")]
 pub enum SentinelPayload {
     #[serde(rename = "sentinel.register")]
-    Register,
+    Register { pin: u32 },
 
     #[serde(rename = "sentinel.frame")]
     Frame { frames: Vec<Frame> },


### PR DESCRIPTION


## Summary

This PR implements the new `sentinel.register` message with the pin field.
To join with a pin, now add the --pin flag e.g. --pin 2345.

To test this, run `cargo run -- --pin 2345` after having created a test (e.g. bruno).

Closes #211 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [X] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [X] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [X] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
