### PR TITLE
Fix/sentinel require pin on version flag

### DIFF
--- a/sentinel/src/lib.rs
+++ b/sentinel/src/lib.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, ValueEnum, arg};
+use clap::{ArgGroup, CommandFactory, FromArgMatches, Parser, ValueEnum, arg};
 use tracing::{error, info};
 
 use crate::recorder::Recorder;
@@ -16,15 +16,19 @@ pub enum Mode {
     Gui,
 }
 
+static EXIT_FLAGS: &[&str] = &["version", "licenses", "licenses_full"];
+static RUNTIME_FLAGS: &[&str] = &["pin", "verbose", "mode"];
+
 #[derive(Parser, Debug, Clone)]
 #[command(about, long_about = None)]
+#[command(group = ArgGroup::new("exit_flags_group").args(EXIT_FLAGS))]
 pub struct Args {
     /// Shows list of per-project licenses
-    #[arg(long, conflicts_with = "licenses_full")]
+    #[arg(long)]
     pub licenses: bool,
 
     /// Shows all projects with their licenses in a pager
-    #[arg(long = "licenses-full", conflicts_with = "licenses")]
+    #[arg(long = "licenses-full")]
     pub licenses_full: bool,
 
     // Print version
@@ -40,8 +44,20 @@ pub struct Args {
     pub verbose: bool,
 
     /// 4-digit pin of the test to join
-    #[arg(long = "pin", short)]
-    pub pin: u32,
+    #[arg(long = "pin", short, required_unless_present_any = EXIT_FLAGS)]
+    pub pin: Option<u32>,
+}
+
+impl Args {
+    pub fn parse() -> Self {
+        let mut cmd = Self::command();
+
+        for &exit_flag in EXIT_FLAGS {
+            cmd = cmd.mut_arg(exit_flag, |arg| arg.conflicts_with_all(RUNTIME_FLAGS));
+        }
+
+        Self::from_arg_matches(&cmd.get_matches()).unwrap_or_else(|e| e.exit())
+    }
 }
 
 pub fn debug() {
@@ -62,7 +78,15 @@ pub async fn start(args: Args) {
         }
     };
 
-    ws::connect_to_server_async(recorder, capture_rx, token.access_token, args.pin).await;
+    // args.pin should never be None if the code is here
+    ws::connect_to_server_async(
+        recorder,
+        capture_rx,
+        token.access_token,
+        args.pin
+            .expect("Tried to get args.pin but was None. This should not happen"),
+    )
+    .await;
 }
 
 mod config {

--- a/sentinel/src/main.rs
+++ b/sentinel/src/main.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::process;
 
 use chrono::Local;
-use clap::Parser;
 use franklyn_sentinel::Args;
 use franklyn_sentinel::VERSION;
 use pager::Pager;


### PR DESCRIPTION
This PR fixes an issue, where runtime flags could be used with exit flags like `version`, `licenses`, etc. where the program then would exit and the runtime flags wouldn't matter at all.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [X] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [X] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
