### PR TITLE
fix(proctor): the lifecycle of WebsocketStore is now improved

### DIFF
--- a/proctor/src/components/NavComponent.vue
+++ b/proctor/src/components/NavComponent.vue
@@ -30,7 +30,7 @@ async function logout() {
   align-items: center;
   width: 100%;
   padding: 0.75rem 1.5rem;
-  background: hsl(185, 72%, 45%);
+  background: var(--primary);
   box-sizing: border-box;
 }
 

--- a/proctor/src/stores/WebsocketStore.ts
+++ b/proctor/src/stores/WebsocketStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import type { ProctorMessage, ServerMessage, SentinelInfo } from '@/types/WebsocketPayloads.ts'
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, reactive, ref, shallowRef, watch } from 'vue'
 import { useKeycloakStore } from './KeycloakStore'
 
 export const useWebsocketStore = defineStore('websocketStore', () => {
@@ -9,17 +9,10 @@ export const useWebsocketStore = defineStore('websocketStore', () => {
   const pageSize = 6
   const framesBySentinel = reactive<Record<string, string>>({})
   const subscribedSentinels = reactive(new Set<string>())
+  const socket = shallowRef<WebSocket | null>(null)
+  const messageQueue: string[] = []
 
   const { keycloak } = useKeycloakStore()
-
-  if (keycloak.token === undefined) {
-    throw new Error('Keycloak token cannot be undefined')
-  }
-
-  const quarkusHeaderProtocol = encodeURIComponent(
-    'quarkus-http-upgrade#Authorization#Bearer ' + keycloak.token,
-  )
-  const socket = new WebSocket('/api/ws/proctor', ['bearer-token-carrier', quarkusHeaderProtocol])
 
   const frameContent = reactive<string[]>([])
 
@@ -33,18 +26,51 @@ export const useWebsocketStore = defineStore('websocketStore', () => {
     timestamp: Math.floor(Date.now() / 1000),
   }
 
-  socket.addEventListener('open', () => {
-    socket.send(JSON.stringify(proctorRegister))
-  })
+  function connect() {
+    if (socket.value) return
 
-  socket.addEventListener('message', (event) => {
-    const requestResult: ServerMessage = JSON.parse(event.data)
-    if (requestResult.type === 'server.update-sentinels') {
-      updateLocalSentinels(requestResult.payload.sentinels)
-    } else if (requestResult.type === 'server.frame') {
-      updateFrames(requestResult.payload.frames)
+    if (keycloak.token === undefined) {
+      throw new Error('Keycloak token cannot be undefined')
     }
-  })
+
+    const quarkusHeaderProtocol = encodeURIComponent(
+      'quarkus-http-upgrade#Authorization#Bearer ' + keycloak.token,
+    )
+    const ws = new WebSocket('/api/ws/proctor', ['bearer-token-carrier', quarkusHeaderProtocol])
+
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify(proctorRegister))
+      while (messageQueue.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ws.send(messageQueue.shift()!)
+      }
+    })
+
+    ws.addEventListener('message', (event) => {
+      const requestResult: ServerMessage = JSON.parse(event.data)
+      if (requestResult.type === 'server.update-sentinels') {
+        updateLocalSentinels(requestResult.payload.sentinels)
+      } else if (requestResult.type === 'server.frame') {
+        updateFrames(requestResult.payload.frames)
+      }
+    })
+
+    socket.value = ws
+  }
+
+  function disconnect() {
+    if (socket.value) {
+      socket.value.close()
+      socket.value = null
+    }
+    sentinelList.value = []
+    for (const key of Object.keys(framesBySentinel)) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete framesBySentinel[key]
+    }
+    subscribedSentinels.clear()
+    messageQueue.length = 0
+  }
 
   function updateLocalSentinels(newSentinels: SentinelInfo[]) {
     const newIds = new Set(newSentinels.map((s) => s.sentinelId))
@@ -61,7 +87,13 @@ export const useWebsocketStore = defineStore('websocketStore', () => {
   }
 
   function sendMessage(message: ProctorMessage) {
-    socket.send(JSON.stringify(message))
+    if (!socket.value) return
+
+    if (socket.value.readyState === WebSocket.OPEN) {
+      socket.value.send(JSON.stringify(message))
+    } else if (socket.value.readyState === WebSocket.CONNECTING) {
+      messageQueue.push(JSON.stringify(message))
+    }
   }
 
   function subscribeToSentinel(sentinelId: string) {
@@ -201,5 +233,7 @@ export const useWebsocketStore = defineStore('websocketStore', () => {
     decreasePageCount,
     increasePageCount,
     setPin,
+    connect,
+    disconnect,
   }
 })

--- a/proctor/src/views/HomeView.vue
+++ b/proctor/src/views/HomeView.vue
@@ -288,15 +288,16 @@ async function goToTest(id: string) {
   border-radius: 20px;
   font-size: 0.85rem;
   font-weight: 600;
-  border: 1px solid var(--border-default);
+  border: none;
   background: var(--bg-card);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.2s ease;
+  box-shadow: inset 0 0 0 2px transparent;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .filter-pill:hover {
-  border-color: var(--primary);
+  background: var(--border-default);
   color: var(--text-primary);
 }
 
@@ -306,20 +307,24 @@ async function goToTest(id: string) {
 }
 
 .filter-pill.active {
-  border-color: transparent;
-  color: white;
+  box-shadow: inset 0 0 0 2px var(--primary);
+  color: var(--primary);
+  background: transparent;
 }
 
 .filter-pill.active.status-live {
-  background: var(--status-live);
+  box-shadow: inset 0 0 0 2px var(--status-live);
+  color: var(--status-live);
 }
 
 .filter-pill.active.status-scheduled {
-  background: var(--status-scheduled);
+  box-shadow: inset 0 0 0 2px var(--status-scheduled);
+  color: var(--status-scheduled);
 }
 
 .filter-pill.active.status-completed {
-  background: var(--status-completed);
+  box-shadow: inset 0 0 0 2px var(--status-completed);
+  color: var(--status-completed);
 }
 
 /* Modal Styles */

--- a/proctor/src/views/NotAllowedView.vue
+++ b/proctor/src/views/NotAllowedView.vue
@@ -44,13 +44,13 @@ async function logout() {
   font-size: 4.5rem;
   font-weight: 500;
   line-height: 1;
-  color: #111;
+  color: var(--text-primary);
 }
 
 .divider {
   width: 1px;
   height: 4rem;
-  background: #e0e0e0;
+  background: var(--border-default);
   flex-shrink: 0;
 }
 
@@ -64,31 +64,32 @@ async function logout() {
   font-size: 1.4rem;
   font-weight: 600;
   margin: 0 0 0.25rem;
+  color: var(--text-primary);
 }
 
 .message {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--text-secondary);
   line-height: 1.2;
 }
 
 .message-low {
   font-size: 0.8rem;
   line-height: 1.2;
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .message-logout {
-  color: #555;
+  color: var(--text-secondary);
   text-underline-offset: 2px;
-  text-decoration-color: #ccc;
+  text-decoration-color: var(--border-strong);
   transition:
     color 0.1s,
     text-decoration-color 0.1s;
 }
 
 .message-logout:hover {
-  color: #111;
-  text-decoration-color: #111;
+  color: var(--text-primary);
+  text-decoration-color: var(--text-primary);
 }
 </style>

--- a/proctor/src/views/ProctoringView.vue
+++ b/proctor/src/views/ProctoringView.vue
@@ -3,14 +3,14 @@ import { useWebsocketStore } from '@/stores/WebsocketStore.ts'
 import { useApolloClientStore } from '@/stores/ApolloClientStore'
 import { gql } from '@apollo/client'
 import { storeToRefs } from 'pinia'
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const { client } = useApolloClientStore()
 const store = useWebsocketStore()
 const { currentPage, totalPages, pagedSentinels, framesBySentinel } = storeToRefs(store)
-const { setProfile, setPin } = store
+const { setProfile, setPin, connect, disconnect } = store
 
 const testId = computed(() => route.params.id as string | undefined)
 const testPin = ref<number | null>(null)
@@ -20,6 +20,8 @@ const expandedSentinelId = ref<string | null>(null)
 const expandedSentinelName = ref<string>('')
 
 onMounted(() => {
+  connect()
+
   if (testId.value) {
     client.query<{ testId: { pin: number; title: string } }>({
       query: gql`
@@ -57,6 +59,10 @@ function closeSentinel() {
   expandedSentinelId.value = null
   expandedSentinelName.value = ''
 }
+
+onUnmounted(() => {
+  disconnect()
+})
 </script>
 
 <template>

--- a/proctor/src/views/TestDetailView.vue
+++ b/proctor/src/views/TestDetailView.vue
@@ -575,17 +575,17 @@ h1 {
 }
 .btn-danger {
   background: transparent;
-  border: 1px solid #ef4444;
+  border: 1px solid var(--error);
   padding: 8px 16px;
   border-radius: 6px;
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
-  color: #ef4444;
+  color: var(--error);
   transition: background 0.15s;
 }
 .btn-danger:hover {
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--alert-error-bg);
 }
 
 .loading-state {


### PR DESCRIPTION
WebsocketStore now exposes connect() and disconnect() functions, so the lifecycle can be cleanly managed by the components using the store.

Related: #237, #242

## Summary

This PR fixes #242.

Also some colors where fixed up to make the 403 site look better on dark mode and replace some colors with color variables.

Fixes: #242 
Related: #237 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [X] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [X] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [X] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
