### PR TITLE
Docs/ws comms auth

### DIFF
--- a/hugo/content/docs/reference/websocket-comm/_index.md
+++ b/hugo/content/docs/reference/websocket-comm/_index.md
@@ -2,7 +2,7 @@
 title: WS Comms Protocol
 ---
 
-Real-time communication between the Franklyn server, Sentinels, and Proctors happens over WebSocket connections using JSON messages with an `Authorization: Bearer <jwt>` header for authentication.
+Real-time communication between the Franklyn server, Sentinels, and Proctors happens over WebSocket connections using JSON messages. Authentication is handled via an `auth` field in the initial register messages.
 
 ## Overview
 

--- a/hugo/content/docs/reference/websocket-comm/lifecycle.md
+++ b/hugo/content/docs/reference/websocket-comm/lifecycle.md
@@ -13,10 +13,11 @@ This document describes the lifecycle of WebSocket connections for both Sentinel
 
 ### Flow
 
-1. Connect to server via WebSocket with `Authorization: Bearer <jwt>` header
-2. Send `sentinel.register` as the first message with PIN code (1337-4200)
+1. Connect to server via WebSocket
+2. Send `sentinel.register` as the first message with PIN code (1337-4200) and `auth` token
 3. Receive `server.registration.ack` or `server.registration.reject`
    - If rejected due to invalid PIN, the reason will be "Invalid PIN"
+   - If rejected due to invalid auth or invalid message, the connection will be closed or rejected
 4. If accepted: receive `server.set-resolution` when the server updates the
    capture resolution
 5. Send `sentinel.frame` every couple of seconds
@@ -64,9 +65,10 @@ deactivate Srv
 
 ### Flow
 
-1. Connect to server via WebSocket with `Authorization: Bearer <jwt>` header
-2. Send `proctor.register` as the first message
+1. Connect to server via WebSocket
+2. Send `proctor.register` as the first message with an `auth` token
 3. Receive `server.registration.ack` or `server.registration.reject`
+   - If rejected due to invalid auth or invalid message, the connection will be closed or rejected
 4. If accepted:
     - Send `proctor.set-pin` to specify which PIN's sentinels to monitor (1337-4200)
     - Receive `server.update-sentinels` with the list of available sentinels for that PIN

--- a/hugo/content/docs/reference/websocket-comm/server-proctor.md
+++ b/hugo/content/docs/reference/websocket-comm/server-proctor.md
@@ -28,7 +28,9 @@ If this message is sent in a registered connection it will just be ignored.
 
 **Payload:**
 
-Empty payload.
+| Field  | Type   | Required | Description          |
+|--------|--------|----------|----------------------|
+| `auth` | string | yes      | Authentication token |
 
 **Example:**
 
@@ -36,7 +38,9 @@ Empty payload.
 {
   "type": "proctor.register",
   "timestamp": 1696969420,
-  "payload": {}
+  "payload": {
+    "auth": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  }
 }
 ```
 

--- a/hugo/content/docs/reference/websocket-comm/server-sentinel.md
+++ b/hugo/content/docs/reference/websocket-comm/server-sentinel.md
@@ -30,6 +30,7 @@ This message must be the first message sent or the sentinel will be disconnected
 | Field | Type   | Required | Description                    |
 |-------|--------|----------|--------------------------------|
 | `pin` | integer| yes      | PIN code (1337-4200)         |
+| `auth`| string | yes      | Authentication token           |
 
 **Example:**
 
@@ -38,7 +39,8 @@ This message must be the first message sent or the sentinel will be disconnected
   "type": "sentinel.register",
   "timestamp": 1696969420,
   "payload": {
-    "pin": 2024
+    "pin": 2024,
+    "auth": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
   }
 }
 ```


### PR DESCRIPTION
## Summary

This PR adds the auth field to the ws-comms protocols register messages

Related: #218 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [X] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [X] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [X] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
