### PR TITLE
docs(release-lifecycle): add better instructions for releasing

### DIFF
--- a/hugo/content/docs/explanation/release-lifecycle.md
+++ b/hugo/content/docs/explanation/release-lifecycle.md
@@ -17,12 +17,15 @@ Any version containing `-` or `+` is treated as a prerelease/dev build.
 
 ## Tagging and VERSION
 
-- Tags are pushed manually and must match the `VERSION` file on that commit.
-- Tag format: `vX.Y.Z`, `vX.Y.Z-rc.N`, `vX.Y.Z+dev.N` (and `-alpha`, `-beta`, etc.).
+- Tags are pushed manually. Before tagging, the `VERSION` file on the target commit
+  must be updated by hand — the tag name with the leading `v` stripped must exactly
+  match its contents (e.g. tag `v0.6.4` requires `VERSION` to contain `0.6.4`).
+- Tag format: `vX.Y.Z`, `vX.Y.Z-rc.N`, `vX.Y.Z+dev.N` (and `-alpha.N`, `-beta.N`, etc.).
 
 Example:
 
 ```bash
+echo -n "0.6.4" > VERSION
 git tag -a v0.6.4 -m "[lts] backport fix"
 git push origin v0.6.4
 ```

--- a/hugo/content/docs/explanation/release-lifecycle.md
+++ b/hugo/content/docs/explanation/release-lifecycle.md
@@ -24,10 +24,12 @@ Any version containing `-` or `+` is treated as a prerelease/dev build.
 
 Example:
 
-```bash
+```shell
 echo -n "0.6.4" > VERSION
+git add VERSION
+git commit -m "chore: bump version to 0.6.4"
 git tag -a v0.6.4 -m "[lts] backport fix"
-git push origin v0.6.4
+git push origin HEAD --follow-tags
 ```
 
 ## LTS and prerelease handling


### PR DESCRIPTION
Add a clarification to the `Tagging and VERSION` part to explicitly tell the reader that the `VERSION` file must be manually updated and that the tag stripped from "v" must match the `VERSION` file of the commit that the tag points to.

Also extend the example to include writing to the VERSION File.

ALso add `N` to the `-alpha.N` additional tag formats.

Crazy bad GitHub ui btw für branch name.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [X] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [X] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
