### PR TITLE
feat: proctor notice banners

### DIFF
--- a/proctor/src/App.vue
+++ b/proctor/src/App.vue
@@ -205,6 +205,13 @@ onMounted(() => {
   font-weight: 800;
 }
 
+.notice-dismiss-spacer {
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-right: 0.75rem;
+  display: inline-block;
+}
+
 .notice-dismiss:hover {
   background: rgba(255, 255, 255, 0.15);
 }
@@ -218,6 +225,15 @@ onMounted(() => {
 .notice-slide-leave-to {
   opacity: 0;
   transform: translateY(-8px);
+}
+
+.notice-slide-leave-active {
+  transition: none;
+}
+
+.notice-slide-leave-to {
+  opacity: 1;
+  transform: none;
 }
 
 @media (max-width: 720px) {
@@ -236,6 +252,10 @@ onMounted(() => {
   }
 
   .notice-dismiss {
+    margin-right: 0.5rem;
+  }
+
+  .notice-dismiss-spacer {
     margin-right: 0.5rem;
   }
 }

--- a/proctor/src/App.vue
+++ b/proctor/src/App.vue
@@ -1,13 +1,242 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { storeToRefs } from 'pinia'
 import NavComponent from './components/NavComponent.vue'
 import { useThemeStore } from './stores/ThemeStore'
+import { useNoticeStore } from './stores/NoticeStore'
+import UiButton from '@/components/ui/Button.vue'
+import type { NoticeType } from '@/types/Notice'
 
 useThemeStore()
+
+const noticeStore = useNoticeStore()
+const { notices } = storeToRefs(noticeStore)
+const { fetchNotices } = noticeStore
+
+const dismissedNoticeIds = ref<Set<string>>(new Set())
+
+const noticeOrder: Record<NoticeType, number> = {
+  ALERT: 0,
+  TIMED: 1,
+  SINGLE: 2,
+}
+
+const activeNotices = computed(() => {
+  const now = Date.now()
+  const dismissed = dismissedNoticeIds.value
+
+  return notices.value
+    .filter((notice) => {
+      if (notice.type !== 'ALERT' && dismissed.has(notice.id)) return false
+      if (notice.type === 'TIMED') {
+        const start = toDate(notice.startTime)
+        const end = toDate(notice.endTime)
+        if (!start || !end) return false
+        return start.getTime() <= now && now <= end.getTime()
+      }
+      return true
+    })
+    .sort((a, b) => {
+      const order = noticeOrder[a.type] - noticeOrder[b.type]
+      if (order !== 0) return order
+      const aStart = toDate(a.startTime)?.getTime() ?? 0
+      const bStart = toDate(b.startTime)?.getTime() ?? 0
+      return bStart - aStart
+    })
+})
+
+function toDate(value: Date | string | null): Date | null {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return isNaN(date.getTime()) ? null : date
+}
+
+function loadDismissedNotices() {
+  try {
+    const raw = localStorage.getItem('franklyn.notice.dismissed')
+    if (!raw) return
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      dismissedNoticeIds.value = new Set(parsed.filter((id) => typeof id === 'string'))
+    }
+  } catch (err) {
+    console.error('Failed to load dismissed notices', err)
+  }
+}
+
+function dismissNotice(notice: Notice) {
+  if (notice.type === 'ALERT') return
+  const next = new Set(dismissedNoticeIds.value)
+  next.add(notice.id)
+  dismissedNoticeIds.value = next
+  localStorage.setItem('franklyn.notice.dismissed', JSON.stringify([...next]))
+}
+
+onMounted(() => {
+  loadDismissedNotices()
+  void fetchNotices()
+})
 </script>
 
 <template>
-  <NavComponent v-if="!$route.meta.hideNav" />
-  <RouterView />
+  <div class="app-shell">
+    <transition-group v-if="activeNotices.length" name="notice-slide" tag="div" class="notice-stack">
+      <section
+        v-for="notice in activeNotices"
+        :key="notice.id"
+        class="notice-banner"
+        :class="`notice-${notice.type.toLowerCase()}`"
+        :role="notice.type === 'ALERT' ? 'alert' : 'status'"
+        :aria-live="notice.type === 'ALERT' ? 'assertive' : 'polite'"
+      >
+        <div class="notice-inner">
+          <div class="notice-content">
+            <p class="notice-text">{{ notice.content }}</p>
+          </div>
+        </div>
+        <button
+          v-if="notice.type !== 'ALERT'"
+          class="notice-dismiss"
+          type="button"
+          @click="dismissNotice(notice)"
+          aria-label="Dismiss notice"
+        >
+          <i class="bi bi-x-lg"></i>
+        </button>
+        <span v-else class="notice-dismiss-spacer" aria-hidden="true"></span>
+      </section>
+    </transition-group>
+    <NavComponent v-if="!$route.meta.hideNav" />
+    <main class="app-main">
+      <RouterView />
+    </main>
+  </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.notice-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.notice-banner {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.2rem 0;
+  border-radius: 0;
+  border: 0;
+  background: var(--bg-card);
+  color: #fff;
+  box-shadow: none;
+  gap: 0.5rem;
+}
+
+.notice-inner {
+  width: min(95%, var(--body-base-width));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.notice-banner.notice-alert {
+  background: var(--error);
+}
+
+.notice-banner.notice-timed {
+  background: var(--warning);
+}
+
+.notice-banner.notice-single {
+  background: var(--info);
+}
+
+.notice-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  flex: 1;
+  text-align: center;
+  padding: 0 0.5rem;
+}
+
+.notice-text {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.notice-dismiss {
+  position: static;
+  margin-right: 0.75rem;
+  border: 0;
+  background: transparent;
+  color: #000;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 800;
+}
+
+.notice-dismiss:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.notice-slide-enter-active,
+.notice-slide-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.notice-slide-enter-from,
+.notice-slide-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+@media (max-width: 720px) {
+  .notice-banner {
+    padding: 0.3rem 0;
+  }
+
+  .notice-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .notice-content {
+    text-align: left;
+    padding: 0;
+  }
+
+  .notice-dismiss {
+    margin-right: 0.5rem;
+  }
+}
+</style>

--- a/proctor/src/App.vue
+++ b/proctor/src/App.vue
@@ -4,8 +4,7 @@ import { storeToRefs } from 'pinia'
 import NavComponent from './components/NavComponent.vue'
 import { useThemeStore } from './stores/ThemeStore'
 import { useNoticeStore } from './stores/NoticeStore'
-import UiButton from '@/components/ui/Button.vue'
-import type { NoticeType } from '@/types/Notice'
+import type { Notice, NoticeType } from '@/types/Notice'
 
 useThemeStore()
 
@@ -95,15 +94,16 @@ onMounted(() => {
           </div>
         </div>
         <button
-          v-if="notice.type !== 'ALERT'"
           class="notice-dismiss"
           type="button"
+          :disabled="notice.type === 'ALERT'"
           @click="dismissNotice(notice)"
+          :aria-hidden="notice.type === 'ALERT'"
+          :tabindex="notice.type === 'ALERT' ? -1 : 0"
           aria-label="Dismiss notice"
         >
           <i class="bi bi-x-lg"></i>
         </button>
-        <span v-else class="notice-dismiss-spacer" aria-hidden="true"></span>
       </section>
     </transition-group>
     <NavComponent v-if="!$route.meta.hideNav" />
@@ -144,7 +144,7 @@ onMounted(() => {
   border-radius: 0;
   border: 0;
   background: var(--bg-card);
-  color: #fff;
+  color: var(--text-primary);
   box-shadow: none;
   gap: 0.5rem;
 }
@@ -160,14 +160,17 @@ onMounted(() => {
 
 .notice-banner.notice-alert {
   background: var(--error);
+  color: var(--text-primary);
 }
 
 .notice-banner.notice-timed {
   background: var(--warning);
+  color: var(--text-primary);
 }
 
 .notice-banner.notice-single {
   background: var(--info);
+  color: var(--text-primary);
 }
 
 .notice-content {
@@ -193,7 +196,7 @@ onMounted(() => {
   margin-right: 0.75rem;
   border: 0;
   background: transparent;
-  color: #000;
+  color: var(--text-primary);
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 999px;
@@ -205,15 +208,13 @@ onMounted(() => {
   font-weight: 800;
 }
 
-.notice-dismiss-spacer {
-  width: 1.5rem;
-  height: 1.5rem;
-  margin-right: 0.75rem;
-  display: inline-block;
+.notice-dismiss:hover {
+  background: rgba(0, 0, 0, 0.12);
 }
 
-.notice-dismiss:hover {
-  background: rgba(255, 255, 255, 0.15);
+.notice-dismiss:disabled {
+  cursor: default;
+  visibility: hidden;
 }
 
 .notice-slide-enter-active,
@@ -255,8 +256,5 @@ onMounted(() => {
     margin-right: 0.5rem;
   }
 
-  .notice-dismiss-spacer {
-    margin-right: 0.5rem;
-  }
 }
 </style>

--- a/proctor/src/App.vue
+++ b/proctor/src/App.vue
@@ -12,7 +12,8 @@ const noticeStore = useNoticeStore()
 const { notices } = storeToRefs(noticeStore)
 const { fetchNotices } = noticeStore
 
-const dismissedNoticeIds = ref<Set<string>>(new Set())
+const dismissedSingleIds = ref<Set<string>>(new Set())
+const dismissedTimedIds = ref<Set<string>>(new Set())
 
 const noticeOrder: Record<NoticeType, number> = {
   ALERT: 0,
@@ -22,11 +23,13 @@ const noticeOrder: Record<NoticeType, number> = {
 
 const activeNotices = computed(() => {
   const now = Date.now()
-  const dismissed = dismissedNoticeIds.value
+  const storedSingles = dismissedSingleIds.value
+  const dismissedTimed = dismissedTimedIds.value
 
   return notices.value
     .filter((notice) => {
-      if (notice.type !== 'ALERT' && dismissed.has(notice.id)) return false
+      if (notice.type === 'SINGLE' && storedSingles.has(notice.id)) return false
+      if (notice.type === 'TIMED' && dismissedTimed.has(notice.id)) return false
       if (notice.type === 'TIMED') {
         const start = toDate(notice.startTime)
         const end = toDate(notice.endTime)
@@ -56,7 +59,7 @@ function loadDismissedNotices() {
     if (!raw) return
     const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) {
-      dismissedNoticeIds.value = new Set(parsed.filter((id) => typeof id === 'string'))
+        dismissedSingleIds.value = new Set(parsed.filter((id) => typeof id === 'string'))
     }
   } catch (err) {
     console.error('Failed to load dismissed notices', err)
@@ -65,10 +68,18 @@ function loadDismissedNotices() {
 
 function dismissNotice(notice: Notice) {
   if (notice.type === 'ALERT') return
-  const next = new Set(dismissedNoticeIds.value)
-  next.add(notice.id)
-  dismissedNoticeIds.value = next
-  localStorage.setItem('franklyn.notice.dismissed', JSON.stringify([...next]))
+
+  if (notice.type === 'TIMED') {
+    const nextTimed = new Set(dismissedTimedIds.value)
+    nextTimed.add(notice.id)
+    dismissedTimedIds.value = nextTimed
+    return
+  }
+
+  const nextStored = new Set(dismissedSingleIds.value)
+  nextStored.add(notice.id)
+  dismissedSingleIds.value = nextStored
+  localStorage.setItem('franklyn.notice.dismissed', JSON.stringify([...nextStored]))
 }
 
 onMounted(() => {

--- a/proctor/src/components/NavComponent.vue
+++ b/proctor/src/components/NavComponent.vue
@@ -78,16 +78,14 @@ async function logout() {
 <<<<<<< HEAD
 =======
 .btn-admin {
-  padding: 0.45rem 0.95rem;
+  padding: 0.45rem 1.1rem;
   border: 1.5px solid hsla(0, 0%, 100%, 0.7);
-  border-radius: 999px;
+  border-radius: 5px;
   background: transparent;
   color: #fff;
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: 0.9rem;
+  font-weight: 500;
   text-decoration: none;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
   transition:
     background 0.2s,
     border-color 0.2s;

--- a/proctor/src/components/NavComponent.vue
+++ b/proctor/src/components/NavComponent.vue
@@ -22,12 +22,12 @@ async function logout() {
       <RouterLink
         v-if="isAdmin"
         to="/admin/notices"
-        class="btn-admin"
+        class="nav-button btn-admin"
         aria-label="Open admin notice banners"
       >
         Admin
       </RouterLink>
-      <button class="btn-logout" @click="logout">Logout</button>
+      <button class="nav-button btn-logout" @click="logout">Logout</button>
     </div>
   </nav>
 </template>
@@ -74,67 +74,37 @@ async function logout() {
   align-items: center;
   gap: 1rem;
 }
-
-<<<<<<< HEAD
-=======
-.btn-admin {
-  padding: 0.45rem 1.1rem;
-  border: 1.5px solid hsla(0, 0%, 100%, 0.7);
-  border-radius: 5px;
-  background: transparent;
-  color: #fff;
-  font-size: 0.9rem;
-  font-weight: 500;
-  text-decoration: none;
-  transition:
-    background 0.2s,
-    border-color 0.2s;
-}
-
-.btn-admin:hover {
-  background: hsla(0, 0%, 100%, 0.15);
-  border-color: #fff;
-}
-
-.btn-settings {
-  width: 2.25rem;
-  height: 2.25rem;
-  border: 1.5px solid hsla(0, 0%, 100%, 0.7);
-  border-radius: 5px;
-  background: transparent;
-  color: #fff;
+.nav-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  text-decoration: none;
-  font-size: 1rem;
-  transition:
-    background 0.2s,
-    border-color 0.2s;
-}
-
-.btn-settings:hover {
-  background: hsla(0, 0%, 100%, 0.15);
-  border-color: #fff;
-}
-
->>>>>>> d733152 (feat(proctor): add admin panel with notice banners CRUD)
-.btn-logout {
   padding: 0.45rem 1.1rem;
-  border: 1.5px solid hsla(0, 0%, 100%, 0.7);
-  border-radius: 5px;
+  border: 1.5px solid hsla(0, 0%, 100%, 0.65);
+  border-radius: 6px;
   background: transparent;
   color: #fff;
   font-size: 0.9rem;
-  font-weight: 500;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
   cursor: pointer;
   transition:
     background 0.2s,
-    border-color 0.2s;
+    border-color 0.2s,
+    transform 0.2s;
 }
 
-.btn-logout:hover {
-  background: hsla(0, 0%, 100%, 0.15);
+.nav-button:hover {
+  background: hsla(0, 0%, 100%, 0.16);
   border-color: #fff;
+}
+
+.nav-button:active {
+  transform: translateY(1px);
+}
+
+.nav-button:focus-visible {
+  outline: 2px solid hsla(0, 0%, 100%, 0.75);
+  outline-offset: 2px;
 }
 </style>

--- a/proctor/src/components/NavComponent.vue
+++ b/proctor/src/components/NavComponent.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
 import { useKeycloakStore } from '@/stores/KeycloakStore'
-import ThemeSwitcher from './ui/ThemeSwitcher.vue'
 
 const kc = useKeycloakStore()
+const isAdmin = computed(() => kc.keycloak.realmAccess?.roles.includes('franklyn-admin'))
 
 async function logout() {
   await kc.keycloak.logout()
@@ -18,7 +19,14 @@ async function logout() {
       </RouterLink>
     </div>
     <div class="navbar-right">
-      <ThemeSwitcher />
+      <RouterLink
+        v-if="isAdmin"
+        to="/admin/notices"
+        class="btn-admin"
+        aria-label="Open admin notice banners"
+      >
+        Admin
+      </RouterLink>
       <button class="btn-logout" @click="logout">Logout</button>
     </div>
   </nav>
@@ -67,6 +75,52 @@ async function logout() {
   gap: 1rem;
 }
 
+<<<<<<< HEAD
+=======
+.btn-admin {
+  padding: 0.45rem 0.95rem;
+  border: 1.5px solid hsla(0, 0%, 100%, 0.7);
+  border-radius: 999px;
+  background: transparent;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.btn-admin:hover {
+  background: hsla(0, 0%, 100%, 0.15);
+  border-color: #fff;
+}
+
+.btn-settings {
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1.5px solid hsla(0, 0%, 100%, 0.7);
+  border-radius: 5px;
+  background: transparent;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-size: 1rem;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.btn-settings:hover {
+  background: hsla(0, 0%, 100%, 0.15);
+  border-color: #fff;
+}
+
+>>>>>>> d733152 (feat(proctor): add admin panel with notice banners CRUD)
 .btn-logout {
   padding: 0.45rem 1.1rem;
   border: 1.5px solid hsla(0, 0%, 100%, 0.7);

--- a/proctor/src/router/index.ts
+++ b/proctor/src/router/index.ts
@@ -5,6 +5,7 @@ import ExamView from '@/views/HomeView.vue'
 import ProctoringView from '@/views/ProctoringView.vue'
 import HomeView from '@/views/HomeView.vue'
 import ExamDetailView from '@/views/ExamDetailView.vue'
+import AdminNoticeBannersView from '@/views/AdminNoticeBannersView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -33,6 +34,11 @@ const router = createRouter({
       path: '/proctoring',
       name: 'proctoring-select',
       component: ProctoringView,
+    },
+    {
+      path: '/admin/notices',
+      name: 'admin-notices',
+      component: AdminNoticeBannersView,
     },
     {
       path: '/not-allowed',

--- a/proctor/src/stores/NoticeStore.ts
+++ b/proctor/src/stores/NoticeStore.ts
@@ -34,7 +34,7 @@ export const useNoticeStore = defineStore('notice', () => {
       const message = err instanceof Error ? err.message : 'Failed to fetch notices'
       error.value = message
       if (message.includes('403')) {
-        error.value = 'Not authorized to view notices. Admin access required.'
+        error.value = 'Not authorized to view notices.'
       }
       console.error(err)
     } finally {

--- a/proctor/src/stores/NoticeStore.ts
+++ b/proctor/src/stores/NoticeStore.ts
@@ -116,11 +116,12 @@ export const useNoticeStore = defineStore('notice', () => {
           },
         },
       })
-      if (res.data?.updateNotice) {
+      const updatedNotice = res.data?.updateNotice
+      if (updatedNotice) {
         notices.value = notices.value.map((notice) =>
-          notice.id === res.data.updateNotice.id ? res.data.updateNotice : notice
+          notice.id === updatedNotice.id ? updatedNotice : notice,
         )
-        return res.data.updateNotice
+        return updatedNotice
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update notice'

--- a/proctor/src/stores/NoticeStore.ts
+++ b/proctor/src/stores/NoticeStore.ts
@@ -1,0 +1,90 @@
+import { gql } from '@apollo/client'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useApolloClientStore } from '@/stores/ApolloClientStore'
+import type { Notice, NoticeType } from '@/types/Notice'
+
+export const useNoticeStore = defineStore('notice', () => {
+  const { client } = useApolloClientStore()
+
+  const notices = ref<Notice[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchNotices() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await client.query<{ notices: Notice[] }>({
+        query: gql`
+          query GetNotices {
+            notices {
+              id
+              type
+              startTime
+              endTime
+              content
+            }
+          }
+        `,
+        fetchPolicy: 'network-only',
+      })
+      if (res.data?.notices) notices.value = [...res.data.notices]
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch notices'
+      error.value = message
+      if (message.includes('403')) {
+        error.value = 'Not authorized to view notices. Admin access required.'
+      }
+      console.error(err)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createNotice(input: {
+    type: NoticeType
+    content: string
+    startTime: Date | null
+    endTime: Date | null
+  }) {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await client.mutate<{ createNotice: Notice }>({
+        mutation: gql`
+          mutation CreateNotice($notice: InsertNoticeInput!) {
+            createNotice(insertNotice: $notice) {
+              id
+              type
+              startTime
+              endTime
+              content
+            }
+          }
+        `,
+        variables: {
+          notice: {
+            type: input.type,
+            content: input.content,
+            startTime: input.startTime?.toISOString(),
+            endTime: input.endTime?.toISOString(),
+          },
+        },
+      })
+      if (res.data?.createNotice) {
+        notices.value = [res.data.createNotice, ...notices.value]
+        return res.data.createNotice
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create notice'
+      error.value = message
+      console.error(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { notices, loading, error, fetchNotices, createNotice }
+})

--- a/proctor/src/stores/NoticeStore.ts
+++ b/proctor/src/stores/NoticeStore.ts
@@ -86,5 +86,53 @@ export const useNoticeStore = defineStore('notice', () => {
     }
   }
 
-  return { notices, loading, error, fetchNotices, createNotice }
+  async function updateNotice(input: {
+    id: string
+    content: string
+    startTime: Date | null
+    endTime: Date | null
+  }) {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await client.mutate<{ updateNotice: Notice }>({
+        mutation: gql`
+          mutation UpdateNotice($id: String!, $notice: UpdateNoticeInput!) {
+            updateNotice(id: $id, updateNotice: $notice) {
+              id
+              type
+              startTime
+              endTime
+              content
+            }
+          }
+        `,
+        variables: {
+          id: input.id,
+          notice: {
+            content: input.content,
+            startTime: input.startTime?.toISOString(),
+            endTime: input.endTime?.toISOString(),
+          },
+        },
+      })
+      if (res.data?.updateNotice) {
+        notices.value = notices.value.map((notice) =>
+          notice.id === res.data.updateNotice.id ? res.data.updateNotice : notice
+        )
+        return res.data.updateNotice
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update notice'
+      if (!message.includes('Unknown type')) {
+        error.value = message
+      }
+      console.error(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { notices, loading, error, fetchNotices, createNotice, updateNotice }
 })

--- a/proctor/src/stores/NoticeStore.ts
+++ b/proctor/src/stores/NoticeStore.ts
@@ -134,5 +134,30 @@ export const useNoticeStore = defineStore('notice', () => {
     }
   }
 
-  return { notices, loading, error, fetchNotices, createNotice, updateNotice }
+  async function deleteNotice(id: string) {
+    loading.value = true
+    error.value = null
+    try {
+      await client.mutate({
+        mutation: gql`
+          mutation DeleteNotice($id: String!) {
+            deleteNotice(id: $id)
+          }
+        `,
+        variables: {
+          id,
+        },
+      })
+      notices.value = notices.value.filter((notice) => notice.id !== id)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete notice'
+      error.value = message
+      console.error(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { notices, loading, error, fetchNotices, createNotice, updateNotice, deleteNotice }
 })

--- a/proctor/src/types/Notice.ts
+++ b/proctor/src/types/Notice.ts
@@ -1,0 +1,9 @@
+export type NoticeType = 'ALERT' | 'TIMED' | 'SINGLE'
+
+export interface Notice {
+  id: string
+  type: NoticeType
+  startTime: Date | null
+  endTime: Date | null
+  content: string
+}

--- a/proctor/src/views/AdminNoticeBannersView.vue
+++ b/proctor/src/views/AdminNoticeBannersView.vue
@@ -1,0 +1,426 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useNoticeStore } from '@/stores/NoticeStore'
+import UiButton from '@/components/ui/Button.vue'
+import type { NoticeType } from '@/types/Notice'
+
+const noticeStore = useNoticeStore()
+const { notices, loading, error } = storeToRefs(noticeStore)
+const { fetchNotices, createNotice } = noticeStore
+
+const showCreateModal = ref(false)
+const noticeType = ref<NoticeType>('ALERT')
+const noticeContent = ref('')
+const noticeStart = ref('')
+const noticeEnd = ref('')
+const createError = ref('')
+
+const hasNotices = computed(() => notices.value.length > 0)
+const sortedNotices = computed(() => {
+  return [...notices.value].sort((a, b) => {
+    const aStart = a.startTime ? new Date(a.startTime).getTime() : 0
+    const bStart = b.startTime ? new Date(b.startTime).getTime() : 0
+    return bStart - aStart
+  })
+})
+
+const canSubmit = computed(() => {
+  if (!noticeContent.value.trim()) return false
+  if (noticeType.value === 'TIMED') return Boolean(noticeStart.value && noticeEnd.value)
+  return true
+})
+
+function formatDate(value: Date | null) {
+  if (!value) return 'N/A'
+  return value.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatTypeLabel(type: NoticeType) {
+  if (type === 'SINGLE') return 'One Time'
+  if (type === 'TIMED') return 'Timed'
+  return 'Alert'
+}
+
+function resetForm() {
+  noticeType.value = 'ALERT'
+  noticeContent.value = ''
+  noticeStart.value = ''
+  noticeEnd.value = ''
+  createError.value = ''
+}
+
+function closeModal() {
+  showCreateModal.value = false
+  resetForm()
+}
+
+function parseDateTime(value: string): Date | null {
+  if (!value) return null
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? null : date
+}
+
+async function submitNotice() {
+  createError.value = ''
+  if (!noticeContent.value.trim()) {
+    createError.value = 'Content is required.'
+    return
+  }
+
+  const startTime = noticeType.value === 'TIMED' ? parseDateTime(noticeStart.value) : null
+  const endTime = noticeType.value === 'TIMED' ? parseDateTime(noticeEnd.value) : null
+
+  if (noticeType.value === 'TIMED') {
+    if (!startTime || !endTime) {
+      createError.value = 'Start and end time are required.'
+      return
+    }
+    if (endTime <= startTime) {
+      createError.value = 'End time must be after start time.'
+      return
+    }
+  }
+
+  try {
+    await createNotice({
+      type: noticeType.value,
+      content: noticeContent.value.trim(),
+      startTime,
+      endTime,
+    })
+    closeModal()
+  } catch (err) {
+    console.error(err)
+    createError.value = 'Failed to create notice.'
+  }
+}
+
+onMounted(() => {
+  void fetchNotices()
+})
+</script>
+
+<template>
+  <main class="view-management">
+    <div class="section-header">
+      <h2>Notice Banners</h2>
+      <UiButton variant="primary" @click="showCreateModal = true">Create notice</UiButton>
+    </div>
+
+    <section class="notice-section">
+      <p v-if="loading" class="status-message">Loading notices...</p>
+      <p v-else-if="error" class="status-message status-error">{{ error }}</p>
+      <p v-else-if="!hasNotices" class="status-message">No notices yet.</p>
+
+      <div v-else class="notice-list">
+        <div v-for="notice in sortedNotices" :key="notice.id" class="notice-row">
+          <div class="notice-row-content">
+            <div class="notice-details">
+              <div class="notice-title-row">
+                <h3 class="notice-title">{{ notice.content }}</h3>
+              </div>
+              <div v-if="notice.type === 'TIMED'" class="notice-meta-row">
+                <span class="notice-meta">{{ formatDate(notice.startTime) }}</span>
+                <span class="notice-meta-separator">·</span>
+                <span class="notice-meta">{{ formatDate(notice.endTime) }}</span>
+              </div>
+            </div>
+            <div class="notice-status-badge">
+              <span class="badge" :class="`status-${notice.type.toLowerCase()}`">
+                {{ formatTypeLabel(notice.type) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div v-if="showCreateModal" class="modal-overlay" @click.self="closeModal">
+      <div class="modal">
+        <header class="modal-header">
+          <h2>Create notice</h2>
+          <button class="icon-button" type="button" @click="closeModal" aria-label="Close">
+            <i class="bi bi-x-lg"></i>
+          </button>
+        </header>
+        <form class="modal-body" @submit.prevent="submitNotice">
+          <div class="form-group">
+            <label for="noticeType">Type</label>
+            <select id="noticeType" v-model="noticeType" class="form-control" required>
+              <option value="ALERT">Alert</option>
+              <option value="TIMED">Timed</option>
+              <option value="SINGLE">One Time</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="noticeContent">Content</label>
+            <textarea
+              id="noticeContent"
+              v-model="noticeContent"
+              class="form-control"
+              rows="4"
+              minlength="3"
+              maxlength="4096"
+              required
+            ></textarea>
+          </div>
+          <div v-if="noticeType === 'TIMED'" class="form-row">
+            <div class="form-group">
+              <label for="noticeStart">Start time</label>
+              <input id="noticeStart" v-model="noticeStart" type="datetime-local" class="form-control" required />
+            </div>
+            <div class="form-group">
+              <label for="noticeEnd">End time</label>
+              <input id="noticeEnd" v-model="noticeEnd" type="datetime-local" class="form-control" required />
+            </div>
+          </div>
+          <p v-if="createError" class="form-error">{{ createError }}</p>
+          <div class="modal-actions">
+            <UiButton variant="secondary" type="button" @click="closeModal">Cancel</UiButton>
+            <UiButton variant="primary" type="submit" :disabled="!canSubmit">Create</UiButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.view-management {
+  padding: 40px;
+  max-width: 1200px;
+  width: min(95%, var(--body-base-width));
+  margin: 0 auto;
+  color: var(--text-primary);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.section-header h2 {
+  color: var(--text-primary);
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.notice-section {
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.status-message {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.status-error {
+  color: var(--error);
+}
+
+.notice-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 1rem;
+}
+
+.notice-row {
+  background: var(--bg-card);
+  padding: 20px 24px;
+  border-radius: 12px;
+  border: 1px solid var(--border-default);
+  transition: all 0.2s ease;
+}
+
+.notice-row:hover {
+  border-color: var(--primary);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+}
+
+.notice-row-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 1rem;
+}
+
+.notice-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.notice-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.notice-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notice-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.notice-meta-separator {
+  color: var(--text-tertiary);
+}
+
+.notice-status-badge {
+  flex-shrink: 0;
+}
+
+.badge {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: white;
+}
+
+.status-alert {
+  background: var(--status-live);
+}
+
+.status-timed {
+  background: var(--status-scheduled);
+}
+
+.status-single {
+  background: var(--status-completed);
+}
+
+@media (max-width: 720px) {
+  .view-management {
+    padding: 20px;
+  }
+
+  .notice-row-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: var(--bg-body);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  padding: 1.25rem;
+  width: 420px;
+  max-width: 92vw;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.icon-button {
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-secondary);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.icon-button:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-group label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.form-control {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.form-control:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.form-error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--error);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+</style>

--- a/proctor/src/views/AdminNoticeBannersView.vue
+++ b/proctor/src/views/AdminNoticeBannersView.vue
@@ -7,7 +7,7 @@ import type { NoticeType } from '@/types/Notice'
 
 const noticeStore = useNoticeStore()
 const { notices, loading, error } = storeToRefs(noticeStore)
-const { fetchNotices, createNotice, updateNotice } = noticeStore
+const { fetchNotices, createNotice, updateNotice, deleteNotice } = noticeStore
 
 const showCreateModal = ref(false)
 const noticeType = ref<NoticeType>('ALERT')
@@ -22,6 +22,10 @@ const editContent = ref('')
 const editStart = ref('')
 const editEnd = ref('')
 const editError = ref('')
+
+const showDeleteModal = ref(false)
+const deleteNoticeId = ref<string | null>(null)
+const deleteError = ref('')
 
 const editNoticeType = computed(() => {
   if (!editNoticeId.value) return null
@@ -91,6 +95,18 @@ function resetEditForm() {
 function closeEditModal() {
   showEditModal.value = false
   resetEditForm()
+}
+
+function openDeleteModal(noticeId: string) {
+  deleteNoticeId.value = noticeId
+  deleteError.value = ''
+  showDeleteModal.value = true
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false
+  deleteNoticeId.value = null
+  deleteError.value = ''
 }
 
 function parseDateTime(value: string): Date | null {
@@ -195,6 +211,18 @@ async function submitEdit() {
   }
 }
 
+async function confirmDelete() {
+  deleteError.value = ''
+  if (!deleteNoticeId.value) return
+  try {
+    await deleteNotice(deleteNoticeId.value)
+    closeDeleteModal()
+  } catch (err) {
+    console.error(err)
+    deleteError.value = 'Failed to delete notice.'
+  }
+}
+
 onMounted(() => {
   void fetchNotices()
 })
@@ -230,6 +258,7 @@ onMounted(() => {
                   {{ formatTypeLabel(notice.type) }}
                 </span>
                 <UiButton variant="secondary" @click="openEditModal(notice)">Edit</UiButton>
+                <UiButton variant="danger" @click="openDeleteModal(notice.id)">Delete</UiButton>
               </div>
             </div>
           </div>
@@ -331,6 +360,25 @@ onMounted(() => {
             <UiButton variant="primary" type="submit">Save changes</UiButton>
           </div>
         </form>
+      </div>
+    </div>
+
+    <div v-if="showDeleteModal" class="modal-overlay" @click.self="closeDeleteModal">
+      <div class="modal">
+        <header class="modal-header">
+          <h2>Delete notice</h2>
+          <button class="icon-button" type="button" @click="closeDeleteModal" aria-label="Close">
+            <i class="bi bi-x-lg"></i>
+          </button>
+        </header>
+        <div class="modal-body">
+          <p class="delete-message">Are you sure you want to delete this notice? This action cannot be undone.</p>
+          <p v-if="deleteError" class="form-error">{{ deleteError }}</p>
+          <div class="modal-actions">
+            <UiButton variant="secondary" type="button" @click="closeDeleteModal">Cancel</UiButton>
+            <UiButton variant="danger" type="button" @click="confirmDelete">Delete</UiButton>
+          </div>
+        </div>
       </div>
     </div>
   </main>
@@ -576,5 +624,11 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   gap: 0.6rem;
+}
+
+.delete-message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
 }
 </style>

--- a/proctor/src/views/AdminNoticeBannersView.vue
+++ b/proctor/src/views/AdminNoticeBannersView.vue
@@ -43,9 +43,16 @@ const canSubmit = computed(() => {
   return true
 })
 
-function formatDate(value: Date | null) {
-  if (!value) return 'N/A'
-  return value.toLocaleString('en-US', {
+function toDate(value: Date | string | null): Date | null {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return isNaN(date.getTime()) ? null : date
+}
+
+function formatDate(value: Date | string | null) {
+  const date = toDate(value)
+  if (!date) return 'N/A'
+  return date.toLocaleString('en-US', {
     year: 'numeric',
     month: 'short',
     day: '2-digit',
@@ -92,13 +99,14 @@ function parseDateTime(value: string): Date | null {
   return isNaN(date.getTime()) ? null : date
 }
 
-function formatDateTimeInput(value: Date | null): string {
-  if (!value) return ''
-  const year = value.getFullYear()
-  const month = `${value.getMonth() + 1}`.padStart(2, '0')
-  const day = `${value.getDate()}`.padStart(2, '0')
-  const hours = `${value.getHours()}`.padStart(2, '0')
-  const minutes = `${value.getMinutes()}`.padStart(2, '0')
+function formatDateTimeInput(value: Date | string | null): string {
+  const date = toDate(value)
+  if (!date) return ''
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  const hours = `${date.getHours()}`.padStart(2, '0')
+  const minutes = `${date.getMinutes()}`.padStart(2, '0')
   return `${year}-${month}-${day}T${hours}:${minutes}`
 }
 
@@ -137,7 +145,12 @@ async function submitNotice() {
   }
 }
 
-function openEditModal(notice: { id: string; content: string; startTime: Date | null; endTime: Date | null }) {
+function openEditModal(notice: {
+  id: string
+  content: string
+  startTime: Date | string | null
+  endTime: Date | string | null
+}) {
   editNoticeId.value = notice.id
   editContent.value = notice.content
   editStart.value = formatDateTimeInput(notice.startTime)

--- a/proctor/src/views/AdminNoticeBannersView.vue
+++ b/proctor/src/views/AdminNoticeBannersView.vue
@@ -225,14 +225,12 @@ onMounted(() => {
                   <span class="notice-meta">{{ formatDate(notice.endTime) }}</span>
                 </div>
               </div>
-              <div class="notice-status-badge">
+              <div class="notice-actions">
                 <span class="badge" :class="`status-${notice.type.toLowerCase()}`">
                   {{ formatTypeLabel(notice.type) }}
                 </span>
+                <UiButton variant="secondary" @click="openEditModal(notice)">Edit</UiButton>
               </div>
-            </div>
-            <div class="notice-actions">
-              <UiButton variant="secondary" @click="openEditModal(notice)">Edit</UiButton>
             </div>
           </div>
         </div>
@@ -390,9 +388,6 @@ onMounted(() => {
   border-radius: 12px;
   border: 1px solid var(--border-default);
   transition: all 0.2s ease;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
 }
 
 .notice-row:hover {
@@ -440,13 +435,12 @@ onMounted(() => {
   color: var(--text-tertiary);
 }
 
-.notice-status-badge {
-  flex-shrink: 0;
-}
-
 .notice-actions {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .badge {
@@ -482,7 +476,8 @@ onMounted(() => {
 
   .notice-actions {
     width: 100%;
-    justify-content: flex-start;
+    justify-content: flex-end;
+    margin-left: 0;
   }
 }
 

--- a/proctor/src/views/AdminNoticeBannersView.vue
+++ b/proctor/src/views/AdminNoticeBannersView.vue
@@ -7,7 +7,7 @@ import type { NoticeType } from '@/types/Notice'
 
 const noticeStore = useNoticeStore()
 const { notices, loading, error } = storeToRefs(noticeStore)
-const { fetchNotices, createNotice } = noticeStore
+const { fetchNotices, createNotice, updateNotice } = noticeStore
 
 const showCreateModal = ref(false)
 const noticeType = ref<NoticeType>('ALERT')
@@ -15,6 +15,18 @@ const noticeContent = ref('')
 const noticeStart = ref('')
 const noticeEnd = ref('')
 const createError = ref('')
+
+const showEditModal = ref(false)
+const editNoticeId = ref<string | null>(null)
+const editContent = ref('')
+const editStart = ref('')
+const editEnd = ref('')
+const editError = ref('')
+
+const editNoticeType = computed(() => {
+  if (!editNoticeId.value) return null
+  return notices.value.find((notice) => notice.id === editNoticeId.value)?.type ?? null
+})
 
 const hasNotices = computed(() => notices.value.length > 0)
 const sortedNotices = computed(() => {
@@ -61,10 +73,33 @@ function closeModal() {
   resetForm()
 }
 
+function resetEditForm() {
+  editNoticeId.value = null
+  editContent.value = ''
+  editStart.value = ''
+  editEnd.value = ''
+  editError.value = ''
+}
+
+function closeEditModal() {
+  showEditModal.value = false
+  resetEditForm()
+}
+
 function parseDateTime(value: string): Date | null {
   if (!value) return null
   const date = new Date(value)
   return isNaN(date.getTime()) ? null : date
+}
+
+function formatDateTimeInput(value: Date | null): string {
+  if (!value) return ''
+  const year = value.getFullYear()
+  const month = `${value.getMonth() + 1}`.padStart(2, '0')
+  const day = `${value.getDate()}`.padStart(2, '0')
+  const hours = `${value.getHours()}`.padStart(2, '0')
+  const minutes = `${value.getMinutes()}`.padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
 }
 
 async function submitNotice() {
@@ -102,6 +137,51 @@ async function submitNotice() {
   }
 }
 
+function openEditModal(notice: { id: string; content: string; startTime: Date | null; endTime: Date | null }) {
+  editNoticeId.value = notice.id
+  editContent.value = notice.content
+  editStart.value = formatDateTimeInput(notice.startTime)
+  editEnd.value = formatDateTimeInput(notice.endTime)
+  editError.value = ''
+  showEditModal.value = true
+}
+
+async function submitEdit() {
+  editError.value = ''
+  if (!editNoticeId.value) return
+  if (!editContent.value.trim()) {
+    editError.value = 'Content is required.'
+    return
+  }
+
+  const startTime = editNoticeType.value === 'TIMED' ? parseDateTime(editStart.value) : null
+  const endTime = editNoticeType.value === 'TIMED' ? parseDateTime(editEnd.value) : null
+
+  if (editNoticeType.value === 'TIMED') {
+    if (!startTime || !endTime) {
+      editError.value = 'Start and end time are required.'
+      return
+    }
+    if (endTime <= startTime) {
+      editError.value = 'End time must be after start time.'
+      return
+    }
+  }
+
+  try {
+    await updateNotice({
+      id: editNoticeId.value,
+      content: editContent.value.trim(),
+      startTime,
+      endTime,
+    })
+    closeEditModal()
+  } catch (err) {
+    console.error(err)
+    editError.value = 'Failed to update notice.'
+  }
+}
+
 onMounted(() => {
   void fetchNotices()
 })
@@ -115,32 +195,35 @@ onMounted(() => {
     </div>
 
     <section class="notice-section">
-      <p v-if="loading" class="status-message">Loading notices...</p>
-      <p v-else-if="error" class="status-message status-error">{{ error }}</p>
+      <p v-if="loading && !hasNotices" class="status-message">Loading notices...</p>
       <p v-else-if="!hasNotices" class="status-message">No notices yet.</p>
+      <p v-if="error" class="status-message status-error">{{ error }}</p>
 
-      <div v-else class="notice-list">
-        <div v-for="notice in sortedNotices" :key="notice.id" class="notice-row">
-          <div class="notice-row-content">
-            <div class="notice-details">
-              <div class="notice-title-row">
-                <h3 class="notice-title">{{ notice.content }}</h3>
+      <div v-if="hasNotices" class="notice-list">
+          <div v-for="notice in sortedNotices" :key="notice.id" class="notice-row">
+            <div class="notice-row-content">
+              <div class="notice-details">
+                <div class="notice-title-row">
+                  <h3 class="notice-title">{{ notice.content }}</h3>
+                </div>
+                <div v-if="notice.type === 'TIMED'" class="notice-meta-row">
+                  <span class="notice-meta">{{ formatDate(notice.startTime) }}</span>
+                  <span class="notice-meta-separator">·</span>
+                  <span class="notice-meta">{{ formatDate(notice.endTime) }}</span>
+                </div>
               </div>
-              <div v-if="notice.type === 'TIMED'" class="notice-meta-row">
-                <span class="notice-meta">{{ formatDate(notice.startTime) }}</span>
-                <span class="notice-meta-separator">·</span>
-                <span class="notice-meta">{{ formatDate(notice.endTime) }}</span>
+              <div class="notice-status-badge">
+                <span class="badge" :class="`status-${notice.type.toLowerCase()}`">
+                  {{ formatTypeLabel(notice.type) }}
+                </span>
               </div>
             </div>
-            <div class="notice-status-badge">
-              <span class="badge" :class="`status-${notice.type.toLowerCase()}`">
-                {{ formatTypeLabel(notice.type) }}
-              </span>
+            <div class="notice-actions">
+              <UiButton variant="secondary" @click="openEditModal(notice)">Edit</UiButton>
             </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
     <div v-if="showCreateModal" class="modal-overlay" @click.self="closeModal">
       <div class="modal">
@@ -185,6 +268,56 @@ onMounted(() => {
           <div class="modal-actions">
             <UiButton variant="secondary" type="button" @click="closeModal">Cancel</UiButton>
             <UiButton variant="primary" type="submit" :disabled="!canSubmit">Create</UiButton>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div v-if="showEditModal" class="modal-overlay" @click.self="closeEditModal">
+      <div class="modal">
+        <header class="modal-header">
+          <h2>Edit notice</h2>
+          <button class="icon-button" type="button" @click="closeEditModal" aria-label="Close">
+            <i class="bi bi-x-lg"></i>
+          </button>
+        </header>
+        <form class="modal-body" @submit.prevent="submitEdit">
+          <div class="form-group">
+            <label for="editNoticeType">Type</label>
+            <input
+              id="editNoticeType"
+              class="form-control"
+              type="text"
+              :value="editNoticeType ? formatTypeLabel(editNoticeType) : ''"
+              disabled
+            />
+          </div>
+          <div class="form-group">
+            <label for="editNoticeContent">Content</label>
+            <textarea
+              id="editNoticeContent"
+              v-model="editContent"
+              class="form-control"
+              rows="4"
+              minlength="3"
+              maxlength="4096"
+              required
+            ></textarea>
+          </div>
+          <div v-if="editNoticeType === 'TIMED'" class="form-row">
+            <div class="form-group">
+              <label for="editNoticeStart">Start time</label>
+              <input id="editNoticeStart" v-model="editStart" type="datetime-local" class="form-control" required />
+            </div>
+            <div class="form-group">
+              <label for="editNoticeEnd">End time</label>
+              <input id="editNoticeEnd" v-model="editEnd" type="datetime-local" class="form-control" required />
+            </div>
+          </div>
+          <p v-if="editError" class="form-error">{{ editError }}</p>
+          <div class="modal-actions">
+            <UiButton variant="secondary" type="button" @click="closeEditModal">Cancel</UiButton>
+            <UiButton variant="primary" type="submit">Save changes</UiButton>
           </div>
         </form>
       </div>
@@ -244,6 +377,9 @@ onMounted(() => {
   border-radius: 12px;
   border: 1px solid var(--border-default);
   transition: all 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .notice-row:hover {
@@ -295,6 +431,11 @@ onMounted(() => {
   flex-shrink: 0;
 }
 
+.notice-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .badge {
   padding: 8px 16px;
   border-radius: 8px;
@@ -324,6 +465,11 @@ onMounted(() => {
   .notice-row-content {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .notice-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/resource/notice/NoticeResource.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/resource/notice/NoticeResource.java
@@ -73,4 +73,10 @@ public class NoticeResource {
 
         return updatedNotice;
     }
+
+    @RolesAllowed("franklyn-admin")
+    @Mutation
+    public void deleteNotice(@NonNull UUID id) {
+        noticeDao.delete(id);
+    }
 }

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/resource/notice/model/InsertNotice.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/resource/notice/model/InsertNotice.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.graphql.NonNull;
 
 public record InsertNotice(
         @NonNull @NotNull NoticeType type,
-        @NonNull @NotNull Instant startTime,
-        @NonNull @NotNull Instant endTime,
+        Instant startTime,
+        Instant endTime,
         @NonNull @NotBlank @Size(min = 3, max = 4096) String content) {
 }


### PR DESCRIPTION
## Summary

Adding Notice banners admin only ui for adding, modifying and deleting notices.

### Users

Notices are shown for all proctor users if they apply.

Related: #129 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [X] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
