### PR TITLE
ci: use personal access token for backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -36,4 +36,5 @@ jobs:
       - name: 🍒 Create backport pull requests
         uses: korthout/backport-action@v4
         with:
+          github_token: ${{ secrets.BACKPORT_PAT }}
           branch_name: 'backport/${pull_number}/${target_branch}'


### PR DESCRIPTION


## Summary

Instead of letting the github actions user create branches, PRs etc, use a PAT.

This allows us to keep the option `Allow GitHub Actions to create and approve pull requests` disabled.

This also makes it possible to run pr-checks on a backport.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
