### PR TITLE
[Backport release/0.6.x] ci: use personal access token for backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -36,4 +36,5 @@ jobs:
       - name: 🍒 Create backport pull requests
         uses: korthout/backport-action@v4
         with:
+          github_token: ${{ secrets.BACKPORT_PAT }}
           branch_name: 'backport/${pull_number}/${target_branch}'


### PR DESCRIPTION
# Description
Backport of #320 to `release/0.6.x`.