### PR TITLE
fix(hugo): make diagrams site link relatively to path prefix

### DIFF
--- a/hugo/assets/css/custom.css
+++ b/hugo/assets/css/custom.css
@@ -183,6 +183,27 @@
   gap: 24px;
 }
 
+body:has(.diagrams-page-sentinel) .diagrams-page {
+  width: 100%;
+  max-width: min(100%, 1200px);
+}
+
+body:has(.diagrams-page-sentinel) {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+body:has(.diagrams-page-sentinel) main {
+  flex: 1 0 auto;
+  width: 100%;
+}
+
+body:has(.diagrams-page-sentinel) footer {
+  margin-top: auto;
+}
+
 .diagrams-hero {
   padding: 24px;
   border-radius: 16px;

--- a/hugo/layouts/diagrams/list.html
+++ b/hugo/layouts/diagrams/list.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
   <div class="hextra-sidebar-container" aria-hidden="true" hidden></div>
   <div class="hextra-max-content-width hx:mx-auto hx:px-6 hx:pt-4 hx:md:px-12 diagrams-page">
+    <span class="diagrams-page-sentinel" aria-hidden="true"></span>
     <header class="diagrams-hero">
       <p class="diagrams-eyebrow">Library</p>
       <h1>{{ .Title }}</h1>

--- a/hugo/layouts/partials/diagrams-tree.html
+++ b/hugo/layouts/partials/diagrams-tree.html
@@ -20,10 +20,10 @@
         {{- partial "diagrams-tree.html" (dict "root" $root "path" $nextPath "scratch" $scratch ) -}}
       </li>
     {{- else if or (strings.HasSuffix $entry.Name ".excalidraw") (strings.HasSuffix $entry.Name ".md") -}}
-      {{- $filePath := printf "/%s/%s" $fullPath $entry.Name -}}
+      {{- $filePath := printf "/%s/%s" $fullPath $entry.Name | relURL -}}
       {{- $scratch.Add "count" 1 -}}
       <li class="diagrams-tree-file">
-        <a class="diagrams-tree-link" href="/excalidraw-viewer.html?file={{ $filePath | urlquery }}">
+        <a class="diagrams-tree-link" href="{{ "/excalidraw-viewer.html" | relURL }}?file={{ $filePath | urlquery }}">
           <span class="diagrams-tree-icon" aria-hidden="true">🗂️</span>
           <span class="diagrams-tree-filename">{{ $entry.Name }}</span>
         </a>


### PR DESCRIPTION


## Summary

This PR fixes a bug in hugo, where clicking on a diagram under /diagrams would replace the url prefix if there was one.

Fixes #300 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [X] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
