### PR TITLE
fix: role normalizing

### DIFF
--- a/server/src/main/java/at/ac/htlleonding/franklynserver/websocket/FranklynWebSocketServer.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/websocket/FranklynWebSocketServer.java
@@ -386,7 +386,7 @@ public class FranklynWebSocketServer {
             JsonWebToken jwt = jwtParser.parse(authToken);
             Set<String> roles = collectRoles(jwt.getGroups(), jwt.getClaim("realm_access"));
             String ldapEntryDn = jwt.getClaim("distinguished_name");
-            UserRole.fromDistinguishedName(ldapEntryDn).ifPresent(role -> roles.add(role.name().toUpperCase()));
+            UserRole.fromDistinguishedName(ldapEntryDn).ifPresent(role -> roles.add(normalizeRole(role.name())));
 
             SecurityIdentity identity = QuarkusSecurityIdentity.builder().setPrincipal(jwt).addRoles(roles).build();
 


### PR DESCRIPTION
## Summary

When connecting to the server via sentinel, I got
 `2026-05-14T10:23:09.963648Z ERROR ThreadId(01) start:connect_to_server_async: src/ws.rs:115: got rejected from the server because of: Insufficient permissions for sentinel`
this is its fix


Fixes #X

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my code
- [ x I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [x] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [x] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
