### PR TITLE
ci: migrate nix cache from JakobHuemer to Franklyn account

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -14,10 +14,10 @@ runs:
     - name: ❄️ Install Nix
       uses: DeterminateSystems/nix-installer-action@main
 
-    - uses: cachix/cachix-action@v15
+    - uses: cachix/cachix-action@v17
       name: ❄️ Setup Cachix
       with:
-        name: franklyn-cachix
+        name: franklyn
         authToken: "${{ inputs.cachix_auth_token }}"
 
     - name: ☕ Setup Maven Cache

--- a/.github/workflows/hugo-deploy.yaml
+++ b/.github/workflows/hugo-deploy.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: hugo
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 📄 Setup Pages
         id: pages

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: proctor
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 🧪 Check Proctor
         run: |
@@ -109,7 +109,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: server
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 🧪 Verify Server
         run: |
@@ -151,7 +151,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: sentinel
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 🧪 Verify Sentinel
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: sentinel
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 🏗️ Build Sentinel Distributable
         run: |
@@ -160,7 +160,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: server
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 🏗️ Build Server
         run: |
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           environment: proctor
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN_V2 }}
 
       - name: 🏗️ Build Proctor
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,16 @@
     crane.url = "github:ipetkov/crane";
   };
 
+  nixConfig = {
+    extra-substituters = [
+      "https://franklyn.cachix.org"
+    ];
+
+    extra-trusted-public-keys = [
+      "franklyn.cachix.org-1:rvchIepdAmB8uOOc1dA7rxhncnDB0LfrFrYb+BhiA4M="
+    ];
+  };
+
   outputs = {flake-parts, ...} @ inputs:
     flake-parts.lib.mkFlake {inherit inputs;} (
       {lib, ...}: {


### PR DESCRIPTION

The nix cache is now franklyn.cachix.org and is managed by the Franklyn account.

The cachix action is also upgrade from version 15 to version 17.

`CACHIX_AUTH_TOKEN` is now `CACHIX_AUTH_TOKEN_V2`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [X] Other (please describe): Cache account change

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [X] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
