### PR TITLE
docs: add ai section to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,19 @@ Fixes #
 - [ ] Documentation update
 - [ ] Other (please describe):
 
+## How was AI used here?
+
+<!-- Did you use AI tools while working on this? Check all that apply. -->
+
+- [ ] Agentic Coding (claude code, codex, opencode)
+  - [ ] Openspec was used to make changes
+- [ ] Inline completion (Copilot, Supermaven, etc.)
+- [ ] Chat
+- [ ] Other:
+
+**How was it used?**
+<!-- e.g. "Used Claude to draft the migration logic, reviewed and adjusted manually" -->
+
 ## Checklist
 
 - [ ] I have performed a self-review of my code


### PR DESCRIPTION
A new section "How was AI used here?" lists options like agentic coding, inline completion, chat, etc. to make the PR more transparent for the creator.

The "how was it used section" gives the PR creator an oportunity to explain how it was used. This should make reviewing PRs more efficient.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [X] Other (please describe): PR Template

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [X] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
