### PR TITLE
feat(proctor): add video generation + download for sessions

### DIFF
--- a/proctor/src/locales/de.json
+++ b/proctor/src/locales/de.json
@@ -66,7 +66,9 @@
     "actions": "Aktionen",
     "download_all": "Alle Herunterladen",
     "students": "Schüler",
-    "download": "Herunterladen"
+    "download": "Herunterladen",
+    "generate": "Generieren",
+    "download_after_exam": "Downloads sind erst nach Ende der Prüfung verfügbar."
   },
   "notices": {
     "title": "Meldungen",

--- a/proctor/src/locales/en.json
+++ b/proctor/src/locales/en.json
@@ -65,7 +65,9 @@
     "actions": "Actions",
     "download_all": "Download all",
     "students": "Students",
-    "download": "Download"
+    "download": "Download",
+    "generate": "Generate",
+    "download_after_exam": "Downloads are available after the exam has ended."
   },
   "notices": {
     "title": "Notices",

--- a/proctor/src/views/ExamDetailView.vue
+++ b/proctor/src/views/ExamDetailView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { useApolloClientStore } from '@/stores/ApolloClientStore'
+import { useKeycloakStore } from '@/stores/KeycloakStore'
 import Button from '@/components/ui/Button.vue'
 import { gql } from '@apollo/client'
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {useI18n} from "vue-i18n";
 
 const { client } = useApolloClientStore()
+const { keycloak } = useKeycloakStore()
 const route = useRoute()
 const router = useRouter()
 const { t, d } = useI18n()
@@ -18,11 +20,17 @@ interface ExamSession {
   sentinelId: string
   examId: string
   videoFilePath: string | null
+  videoStatus: string | null
   user: {
     preferredUsername: string
     givenName: string | null
     familyName: string | null
   } | null
+}
+
+interface VideoState {
+  status: string | null
+  pendingDownload: boolean
 }
 
 interface Exam {
@@ -38,6 +46,31 @@ interface Exam {
 
 const examData = ref<Exam | null>(null)
 const sessions = ref<ExamSession[]>([])
+const videoStates = ref<Record<string, VideoState>>({})
+let pollInterval: ReturnType<typeof setInterval> | null = null
+
+const ALL_STUDENTS_QUERY = gql`
+  query AllStudents($examId: String!) {
+    allStudents(examId: $examId) {
+      studentId
+      sentinelId
+      examId
+      videoFilePath
+      videoStatus
+      user {
+        preferredUsername
+        givenName
+        familyName
+      }
+    }
+  }
+`
+
+const GENERATE_VIDEO_MUTATION = gql`
+  mutation GenerateSentinelVideo($sentinelId: String!) {
+    generateSentinelVideo(sentinelId: $sentinelId)
+  }
+`
 
 const showEditModal = ref(false)
 const showDeleteModal = ref(false)
@@ -80,36 +113,154 @@ function fetchExam() {
 function fetchStudents() {
   client
     .query<{ allStudents: ExamSession[] }>({
-      query: gql`
-        query AllStudents($examId: String!) {
-          allStudents(examId: $examId) {
-            studentId
-            sentinelId
-            examId
-            videoFilePath
-            user {
-              preferredUsername
-              givenName
-              familyName
-            }
-          }
-        }
-      `,
+      query: ALL_STUDENTS_QUERY,
       variables: { examId },
       fetchPolicy: 'network-only',
     })
     .then((res) => {
       sessions.value = res.data?.allStudents ?? []
+      for (const s of sessions.value) {
+        videoStates.value[s.sentinelId] = {
+          status: s.videoStatus ?? null,
+          pendingDownload: false,
+        }
+      }
+      if (Object.values(videoStates.value).some((v) => v.status === 'PENDING')) {
+        startPolling()
+      }
     })
     .catch((e) => {
       console.error('Failed to fetch students!', e)
     })
 }
 
+function startPolling() {
+  if (!pollInterval) pollInterval = setInterval(pollVideoStatuses, 2000)
+}
+
+function stopPolling() {
+  if (pollInterval) {
+    clearInterval(pollInterval)
+    pollInterval = null
+  }
+}
+
+async function pollVideoStatuses() {
+  try {
+    const res = await client.query<{ allStudents: ExamSession[] }>({
+      query: ALL_STUDENTS_QUERY,
+      variables: { examId },
+      fetchPolicy: 'network-only',
+    })
+    for (const s of res.data?.allStudents ?? []) {
+      const local = videoStates.value[s.sentinelId]
+      if (!local) continue
+      const newStatus = s.videoStatus ?? null
+      if (local.status !== newStatus) {
+        local.status = newStatus
+        if (newStatus === 'DONE' && local.pendingDownload) {
+          local.pendingDownload = false
+          triggerDownload(s.sentinelId)
+        }
+      }
+    }
+    if (!Object.values(videoStates.value).some((v) => v.status === 'PENDING')) {
+      stopPolling()
+    }
+  } catch (e) {
+    console.error('Failed to poll video statuses', e)
+  }
+}
+
+function buildFilename(sentinelId: string): string {
+  const session = sessions.value.find((s) => s.sentinelId === sentinelId)
+  const lastName = session?.user?.familyName ?? ''
+  const firstName = session?.user?.givenName ?? ''
+  const exam = (examData.value?.title ?? sentinelId)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  const baseName =
+    [lastName, firstName].filter(Boolean).join('_') ||
+    session?.user?.preferredUsername ||
+    sentinelId
+  const idx = sessionIndexMap.value[sentinelId] ?? 0
+  const namePart = idx === 0 ? baseName : `${baseName}_(${idx})`
+  return `${namePart}_${exam}.mp4`
+}
+
+async function triggerDownload(sentinelId: string) {
+  try {
+    await keycloak.updateToken(30)
+  } catch {
+    await keycloak.login()
+    return
+  }
+  const res = await fetch(`/api/videos/${sentinelId}.mp4`, {
+    headers: { Authorization: `Bearer ${keycloak.token}` },
+  })
+  if (!res.ok) {
+    console.error('Video download failed', res.status)
+    return
+  }
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = buildFilename(sentinelId)
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+async function handleDownload(sentinelId: string) {
+  if (examStatus.value !== 'completed') return
+  const state = videoStates.value[sentinelId]
+  if (!state || state.status === 'PENDING') return
+
+  if (state.status === 'DONE') {
+    triggerDownload(sentinelId)
+    return
+  }
+
+  try {
+    await client.mutate({ mutation: GENERATE_VIDEO_MUTATION, variables: { sentinelId } })
+    state.status = 'PENDING'
+    state.pendingDownload = true
+    startPolling()
+  } catch (e) {
+    console.error('Failed to generate video', sentinelId, e)
+  }
+}
+
+async function downloadAll() {
+  if (examStatus.value !== 'completed') return
+  const done = sessions.value.filter((s) => videoStates.value[s.sentinelId]?.status === 'DONE')
+  const toGenerate = sessions.value.filter(
+    (s) => (videoStates.value[s.sentinelId]?.status ?? null) === null,
+  )
+
+  for (const s of done) {
+    await triggerDownload(s.sentinelId)
+  }
+
+  for (const s of toGenerate) {
+    await client
+      .mutate({ mutation: GENERATE_VIDEO_MUTATION, variables: { sentinelId: s.sentinelId } })
+      .then(() => {
+        videoStates.value[s.sentinelId].status = 'PENDING'
+      })
+      .catch((e) => console.error('generate failed', s.sentinelId, e))
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+  if (toGenerate.length) startPolling()
+}
+
 onMounted(() => {
   fetchExam()
   fetchStudents()
 })
+
+onUnmounted(stopPolling)
 
 const examStatus = computed(() => {
   if (!examData.value?.startedAt) return 'scheduled'
@@ -123,20 +274,35 @@ const examStatusTranslated = computed(() => {
   return t('exams.completed')
 })
 
-const sessionList = computed(() => {
-  const sentinelCounts: Record<string, number> = {}
-  return sessions.value.map((s) => {
-    const prevCount = sentinelCounts[s.sentinelId] ?? 0
-    sentinelCounts[s.sentinelId] = prevCount + 1
+// sentinelId is UUID v7 (time-sortable) — sort ascending = chronological order
+const sessionsSortedBySentinel = computed(() =>
+  [...sessions.value].sort((a, b) => a.sentinelId.localeCompare(b.sentinelId)),
+)
+
+// Maps sentinelId → per-student session index (0 = first, 1 = second, …)
+const sessionIndexMap = computed(() => {
+  const studentCount: Record<string, number> = {}
+  const map: Record<string, number> = {}
+  for (const s of sessionsSortedBySentinel.value) {
+    const count = studentCount[s.studentId] ?? 0
+    map[s.sentinelId] = count
+    studentCount[s.studentId] = count + 1
+  }
+  return map
+})
+
+const sessionList = computed(() =>
+  sessionsSortedBySentinel.value.map((s) => {
+    const idx = sessionIndexMap.value[s.sentinelId] ?? 0
     const name = s.user
       ? [s.user.givenName, s.user.familyName].filter(Boolean).join(' ') || s.user.preferredUsername
       : s.studentId.slice(0, 8)
     return {
       ...s,
-      displayName: prevCount === 0 ? name : `${name} (${prevCount})`,
+      displayName: idx === 0 ? name : `${name} (${idx})`,
     }
-  })
-})
+  }),
+)
 
 function openEditModal() {
   if (!examData.value) return
@@ -316,10 +482,32 @@ async function copyUuid() {
       <!-- Left: Students -->
       <div class="sessions-card">
         <h3>{{t('detail.students')}}</h3>
+        <p v-if="examStatus !== 'completed'" class="download-notice">
+          <i class="bi bi-info-circle"></i>
+          {{ t('detail.download_after_exam') }}
+        </p>
         <div class="session-list">
           <div v-for="session in sessionList" :key="session.studentId" class="session-row">
             <span class="session-name">{{ session.displayName }}</span>
-            <Button variant="secondary" disabled>{{t('detail.download')}}</Button>
+            <Button
+              variant="secondary"
+              :class="{
+                'btn-not-generated':
+                  !videoStates[session.sentinelId]?.status ||
+                  videoStates[session.sentinelId]?.status === 'FAILED',
+                'btn-generated': videoStates[session.sentinelId]?.status === 'DONE',
+              }"
+              :loading="videoStates[session.sentinelId]?.status === 'PENDING'"
+              :disabled="examStatus !== 'completed'"
+              :title="examStatus !== 'completed' ? t('detail.download_after_exam') : undefined"
+              @click="handleDownload(session.sentinelId)"
+            >
+              <span
+                v-if="videoStates[session.sentinelId]?.status === 'PENDING'"
+                class="spinner"
+              ></span>
+              {{ t('detail.download') }}
+            </Button>
           </div>
         </div>
       </div>
@@ -364,7 +552,7 @@ async function copyUuid() {
             <Button variant="secondary" @click="router.push(`/proctoring/${examId}`)">
               {{t('detail.proctoring')}}
             </Button>
-            <Button variant="secondary" disabled>{{t('detail.download_all')}}</Button>
+            <Button variant="secondary" :disabled="examStatus !== 'completed'" :title="examStatus !== 'completed' ? t('detail.download_after_exam') : undefined" @click="downloadAll">{{t('detail.download_all')}}</Button>
             <Button variant="secondary" @click="openEditModal">{{t('detail.edit')}}</Button>
             <Button v-if="examStatus === 'scheduled'" variant="primary" @click="startExam">
               {{t('detail.start')}}
@@ -736,5 +924,41 @@ h1 {
   font-size: 0.875rem;
   margin: 0 0 20px;
   line-height: 1.5;
+}
+
+.btn-generated {
+  border-color: var(--primary) !important;
+  color: var(--primary) !important;
+}
+
+.download-notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--warning);
+  background: var(--alert-warning-bg);
+  border: 1px solid var(--warning);
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin: 0 0 16px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/proctor/src/views/ExamDetailView.vue
+++ b/proctor/src/views/ExamDetailView.vue
@@ -135,7 +135,7 @@ function fetchStudents() {
 }
 
 function startPolling() {
-  if (!pollInterval) pollInterval = setInterval(pollVideoStatuses, 2000)
+  pollInterval ??= setInterval(pollVideoStatuses, 2000)
 }
 
 function stopPolling() {
@@ -160,7 +160,7 @@ async function pollVideoStatuses() {
         local.status = newStatus
         if (newStatus === 'DONE' && local.pendingDownload) {
           local.pendingDownload = false
-          triggerDownload(s.sentinelId)
+          void triggerDownload(s.sentinelId)
         }
       }
     }
@@ -181,8 +181,8 @@ function buildFilename(sentinelId: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
   const baseName =
-    [lastName, firstName].filter(Boolean).join('_') ||
-    session?.user?.preferredUsername ||
+    [lastName, firstName].filter(Boolean).join('_') ??
+    session?.user?.preferredUsername ??
     sentinelId
   const idx = sessionIndexMap.value[sentinelId] ?? 0
   const namePart = idx === 0 ? baseName : `${baseName}_(${idx})`
@@ -218,7 +218,7 @@ async function handleDownload(sentinelId: string) {
   if (!state || state.status === 'PENDING') return
 
   if (state.status === 'DONE') {
-    triggerDownload(sentinelId)
+    void triggerDownload(sentinelId)
     return
   }
 
@@ -247,8 +247,11 @@ async function downloadAll() {
     await client
       .mutate({ mutation: GENERATE_VIDEO_MUTATION, variables: { sentinelId: s.sentinelId } })
       .then(() => {
-        videoStates.value[s.sentinelId].status = 'PENDING'
-        videoStates.value[s.sentinelId].pendingDownload = true
+        const state = videoStates.value[s.sentinelId]
+        if (state) {
+          state.status = 'PENDING'
+          state.pendingDownload = true
+        }
       })
       .catch((e) => console.error('generate failed', s.sentinelId, e))
     await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/proctor/src/views/ExamDetailView.vue
+++ b/proctor/src/views/ExamDetailView.vue
@@ -248,6 +248,7 @@ async function downloadAll() {
       .mutate({ mutation: GENERATE_VIDEO_MUTATION, variables: { sentinelId: s.sentinelId } })
       .then(() => {
         videoStates.value[s.sentinelId].status = 'PENDING'
+        videoStates.value[s.sentinelId].pendingDownload = true
       })
       .catch((e) => console.error('generate failed', s.sentinelId, e))
     await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/server/http/get video info.yml
+++ b/server/http/get video info.yml
@@ -1,5 +1,5 @@
 info:
-  name: schedule generation info
+  name: get video info
   type: graphql
   seq: 21
 
@@ -9,7 +9,7 @@ graphql:
   body:
     query: |-
       query getVideoInfo {
-        videoStatus (sentinelId: "3c1202de-d9c8-4b3d-a2d2-b1f5746b10e0") {
+        videoStatus (sentinelId: "bee8d4b1-9f46-473f-96fd-d3ce3d310db9") {
           link
           state
         }

--- a/server/http/get video.yml
+++ b/server/http/get video.yml
@@ -8,7 +8,7 @@ http:
   url: "{{BASE_URL}}/api/videos/:video"
   params:
     - name: video
-      value: ""
+      value: 0892e811-04d0-4f32-bdf9-6d15889d3c40
       type: path
   auth: inherit
 

--- a/server/http/opencollection.yml
+++ b/server/http/opencollection.yml
@@ -23,7 +23,7 @@ request:
       clientId: sentinel
       placement: basic_auth_header
     resourceOwner:
-      username: srv-teacher
+      username: "{{KLC_USERNAME}}"
       password: "{{KLC_PASSWORD}}"
     scope: openid
     tokenConfig:

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -136,6 +136,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+        </dependency>
         <!-- Source: https://mvnrepository.com/artifact/org.jdbi/jdbi3-core -->
         <dependency>
             <groupId>org.jdbi</groupId>

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/resource/video/VideoResource.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/resource/video/VideoResource.java
@@ -4,6 +4,7 @@ import at.ac.htlleonding.franklynserver.repository.exam.ExamSessionDao;
 import at.ac.htlleonding.franklynserver.repository.exam.model.ExamSession;
 import at.ac.htlleonding.franklynserver.resource.error.EntityNotFoundException;
 import at.ac.htlleonding.franklynserver.service.VideoService;
+import io.quarkus.logging.Log;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/resource/video/VideoResource.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/resource/video/VideoResource.java
@@ -4,7 +4,6 @@ import at.ac.htlleonding.franklynserver.repository.exam.ExamSessionDao;
 import at.ac.htlleonding.franklynserver.repository.exam.model.ExamSession;
 import at.ac.htlleonding.franklynserver.resource.error.EntityNotFoundException;
 import at.ac.htlleonding.franklynserver.service.VideoService;
-import io.quarkus.logging.Log;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/service/VideoService.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/service/VideoService.java
@@ -79,7 +79,7 @@ public class VideoService {
                     try {
                         examSessionDao.updateVideo(sentinelId, "FAILED", null);
                     } catch (Exception dbEx) {
-                        Log.errorf(dbEx, "Failed to set FAILED status in exceptionally handler for sentinel %s", sentinelId);
+                        Log.errorf(dbEx, "Failed to set FAILED status in exceptionally handler for %s", sentinelId);
                     }
                     return null;
                 });

--- a/server/src/main/java/at/ac/htlleonding/franklynserver/service/VideoService.java
+++ b/server/src/main/java/at/ac/htlleonding/franklynserver/service/VideoService.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.microprofile.context.ManagedExecutor;
 
 @ApplicationScoped
 public class VideoService {
@@ -36,6 +37,9 @@ public class VideoService {
     @Inject
     FranklynConfig config;
 
+    @Inject
+    ManagedExecutor managedExecutor;
+
     private String buildFilename(ExamSession session, UUID sentinelId) {
         if (session == null) {
             return sentinelId.toString();
@@ -54,7 +58,7 @@ public class VideoService {
         return name.replaceAll("[^a-zA-Z0-9_\\-]", "_");
     }
 
-    private Path resolveUniqueOutputPath(Path storageDir, String baseName) {
+    private synchronized Path resolveUniqueOutputPath(Path storageDir, String baseName) {
         Path candidate = storageDir.resolve(baseName + ".mp4");
         if (!Files.exists(candidate)) {
             return candidate;
@@ -69,12 +73,23 @@ public class VideoService {
 
     public void scheduleVideoGeneration(UUID sentinelId) {
         examSessionDao.setPendingStatus(sentinelId);
-        CompletableFuture.runAsync(() -> generateVideo(sentinelId));
+        CompletableFuture.runAsync(() -> generateVideo(sentinelId), managedExecutor)
+                .exceptionally(e -> {
+                    Log.errorf(e, "Unhandled exception escaping generateVideo for sentinel %s", sentinelId);
+                    try {
+                        examSessionDao.updateVideo(sentinelId, "FAILED", null);
+                    } catch (Exception dbEx) {
+                        Log.errorf(dbEx, "Failed to set FAILED status in exceptionally handler for sentinel %s", sentinelId);
+                    }
+                    return null;
+                });
     }
 
     private void generateVideo(UUID sentinelId) {
+        Log.debugf("[video] generateVideo start sentinel=%s thread=%s", sentinelId, Thread.currentThread().getName());
+
         if (!frameStore.hasFrames(sentinelId)) {
-            Log.warnf("No frames stored for sentinel %s, skipping video generation", sentinelId);
+            Log.warnf("[video] no frames for sentinel=%s, marking FAILED", sentinelId);
             examSessionDao.updateVideo(sentinelId, "FAILED", null);
             return;
         }
@@ -87,6 +102,7 @@ public class VideoService {
             ExamSession session = examSessionDao.findBySentinelId(sentinelId).orElse(null);
             String filename = buildFilename(session, sentinelId);
             Path outputPath = resolveUniqueOutputPath(storageDir, filename);
+            Log.debugf("[video] sentinel=%s outputPath=%s", sentinelId, outputPath);
 
             Process process = new ProcessBuilder(
                     "ffmpeg",
@@ -95,21 +111,28 @@ public class VideoService {
                     "-c:v", "libx264",
                     "-pix_fmt", "yuv420p",
                     outputPath.toString())
-                    .redirectErrorStream(true)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
                     .start();
 
             int exitCode = process.waitFor();
+            Log.debugf("[video] sentinel=%s ffmpeg exit=%d", sentinelId, exitCode);
             if (exitCode != 0) {
-                Log.errorf("ffmpeg exited with code %d for sentinel %s", exitCode, sentinelId);
+                Log.errorf("[video] ffmpeg exit=%d sentinel=%s", exitCode, sentinelId);
                 examSessionDao.updateVideo(sentinelId, "FAILED", null);
                 return;
             }
 
+            Log.debugf("[video] sentinel=%s calling updateVideo DONE path=%s", sentinelId, outputPath);
             examSessionDao.updateVideo(sentinelId, "DONE", outputPath.toString());
-            Log.infof("Video generation complete for sentinel %s", sentinelId);
+            Log.infof("[video] generation complete sentinel=%s", sentinelId);
         } catch (IOException | InterruptedException e) {
-            Log.errorf("Video generation failed for sentinel %s: %s", sentinelId, e.getMessage());
-            examSessionDao.updateVideo(sentinelId, "FAILED", null);
+            Log.errorf(e, "[video] generation failed sentinel=%s", sentinelId);
+            try {
+                examSessionDao.updateVideo(sentinelId, "FAILED", null);
+            } catch (Exception dbEx) {
+                Log.errorf(dbEx, "[video] also failed to set FAILED status sentinel=%s", sentinelId);
+            }
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -69,3 +69,6 @@ franklyn.pin.max=4200
 
 # Video Storage Configuration
 franklyn.video.storage-dir=/tmp/franklyn-videos
+
+# Video generation debug logging
+quarkus.log.category."at.ac.htlleonding.franklynserver.service.VideoService".level=DEBUG


### PR DESCRIPTION
## Summary

Teachers can now download exam session recordings from the exam detail view. Each student session has a download button that triggers video generation and automatically downloads the file once
ready. A "Download All" button handles all sessions at once. Downloads are only available after the exam has ended.

### Video Generation & Status

Generation is triggered per sentinel via the existing generateSentinelVideo mutation. Status is tracked by polling allStudents every 2 seconds — one request covers all sessions simultaneously.

The backend had two bugs blocking concurrent generation: the async task ran on an unmanaged thread pool, losing CDI context and silently failing all JDBI calls except the first; and ffmpeg's
output pipe was never drained, causing waitFor() to deadlock on longer recordings. The bugs are still not completely fixed though and only improve logging and make generation more stable.

Closes: #314 
Closes: #308 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [X] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [X] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
