### PR TITLE
feat: add button

### DIFF
--- a/proctor/src/locales/de.json
+++ b/proctor/src/locales/de.json
@@ -39,7 +39,8 @@
     "waiting": "Warte auf Bild.",
     "next": "Nächste",
     "previous": "Vorherige",
-    "page": "Seite"
+    "page": "Seite",
+    "back_exam": "Zurück zum Test"
   },
   "not_allowed": {
     "title": "Zugriff nicht gestattet",

--- a/proctor/src/locales/en.json
+++ b/proctor/src/locales/en.json
@@ -38,7 +38,8 @@
     "waiting": "Waiting for frame",
     "next": "Next",
     "previous": "Previous",
-    "page": "Page"
+    "page": "Page",
+    "back_exam": "Back to Exam"
   },
   "not_allowed": {
     "title": "Access Denied",

--- a/proctor/src/views/ProctoringView.vue
+++ b/proctor/src/views/ProctoringView.vue
@@ -83,6 +83,9 @@ onUnmounted(() => {
         <h2>
           {{ examTitle }} <span class="pin-badge">{{ examPin }}</span>
         </h2>
+        <Button as="router-link" :to="`/exams/${examId}`" variant="secondary" icon="bi-arrow-left">
+          {{ t('proctoring.back_exam') }}
+        </Button>
       </div>
       <div class="frame-grid">
         <div
@@ -305,6 +308,9 @@ onUnmounted(() => {
 
 .proctor-header {
   margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .proctor-header h2 {


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this change. What problem does it solve? Link to related issues. -->

READ the issue

Fixes #328 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [x] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [ ] Chat
- [ ] Other:

**How was it used?**
<!-- e.g. "Used Claude to draft the migration logic, reviewed and adjusted manually" -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [x] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [x] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
