### PR TITLE
feat(sentinel): add system level configuration defaults

### DIFF
--- a/sentinel/src/config.rs
+++ b/sentinel/src/config.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::{path::PathBuf, sync::LazyLock};
 
 use config::{Config, Environment, File, FileFormat};
 use directories::ProjectDirs;
@@ -35,6 +35,7 @@ impl AppConfig {
         }
 
         config_builder = config_builder
+            .add_source(File::from(system_config_path()).required(false))
             .add_source(File::from(config_path()).required(false))
             .add_source(Environment::with_prefix("FRANKLYN"));
 
@@ -46,11 +47,42 @@ impl AppConfig {
     }
 }
 
-fn config_path() -> std::path::PathBuf {
-    ProjectDirs::from("at", "htl-leonding", "franklyn")
+static QUALIFIER: &'static str = "at";
+static ORGANIZATION: &'static str = "htl-leonding";
+static APPLICATION: &'static str = "franklyn";
+
+fn config_path() -> PathBuf {
+    ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
         .expect("no valid home directory")
         .config_dir()
         .join("config.toml")
+}
+
+fn system_config_path() -> PathBuf {
+    if let Ok(data_dir) = std::env::var("FRANKLYN_DATA_DIR") {
+        return PathBuf::from(data_dir).join("config.toml");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let base = std::env::var("PROGRAMDATA").unwrap_or_else(|_| "C:\\ProgramData".to_string());
+        PathBuf::from(base)
+            .join(ORGANIZATION)
+            .join(APPLICATION)
+            .join("config.toml")
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/Library/Application Support")
+            .join(format!("{}.{}.{}", QUALIFIER, ORGANIZATION, APPLICATION))
+            .join("config.toml")
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        PathBuf::from("/etc").join(APPLICATION).join("config.toml")
+    }
 }
 
 fn read_config() -> String {


### PR DESCRIPTION

## Summary

This PR makes sentinel check for system level configuration at the OS-specific locations that act as default for every user.

### How to test

make a file at `/etc/franklyn/config.toml` setting `api_url` to some non default value.
Then run `franklyn config list` and observe that `api_url` is now that new value. Make sure that no user specific configuration is overriding `api_url`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [ ] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [X] Inline completion (Copilot, Supermaven, etc.)
- [X] Chat
- [ ] Other:

**How was it used?**

Find out, where the system level configuration for an app is for all users.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [X] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
