### PR TITLE
docs: add student, teacher, and administrator guides

### DIFF
--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -16,7 +16,8 @@ layout: hextra-home
 
 <div class="hx:mb-6">
     <span class="hx:mr-2">{{< hextra/hero-button text="For Students" link="guide/students" >}}</span>
-    {{< hextra/hero-button text="Proctor an exam" link="proctor" >}}
+    <span class="hx:mr-2">{{< hextra/hero-button text="Proctor an exam" link="proctor" >}}</span>
+    {{< hextra/hero-button text="Prepare an Exam" link="guide/teachers/preparing-students" style="background-color: #64748b;" >}}
 </div>
 
 <div class="hx:mt-6">

--- a/hugo/content/guide/administrators/_index.md
+++ b/hugo/content/guide/administrators/_index.md
@@ -1,0 +1,9 @@
+---
+title: Administrator Guide
+description: Deploy and configure Franklyn
+weight: 30
+---
+
+Configuration and deployment reference for administrators managing a Franklyn installation.
+
+- [Sentinel Configuration](sentinel-configuration): config file locations, keys, and environment variable overrides

--- a/hugo/content/guide/administrators/sentinel-configuration.md
+++ b/hugo/content/guide/administrators/sentinel-configuration.md
@@ -1,0 +1,67 @@
+---
+title: Sentinel Configuration
+description: Configuration file locations, keys, and environment variable overrides for Franklyn Sentinel
+weight: 10
+---
+
+## Configuration File Paths
+
+Sentinel supports two levels of configuration: system-level (applies to all users on the machine) and user-level (per user, overrides system-level).
+
+**System-level:**
+
+| OS | Path |
+|---|---|
+| Linux | `/etc/franklyn/config.toml` |
+| macOS | `/Library/Application Support/at.htl-leonding.franklyn/config.toml` |
+| Windows | `%PROGRAMDATA%\htl-leonding\franklyn\config.toml` |
+
+**User-level:**
+
+| OS | Path |
+|---|---|
+| Linux | `~/.config/franklyn/config.toml` |
+| macOS | `~/Library/Application Support/at.htl-leonding.franklyn/config.toml` |
+| Windows | `%LOCALAPPDATA%\htl-leonding\franklyn\config` |
+
+You can also set the `FRANKLYN_DATA_DIR` environment variable to point to a custom directory; Sentinel will read `$FRANKLYN_DATA_DIR/config.toml` as the system config instead of the default OS path.
+
+> The user-level config directory and an empty file are created automatically on first `franklyn config set` or `franklyn config edit`. System-level paths can't be managed by the franklyn program.
+
+## Configuration Keys
+
+| Key | Default | Description |
+|---|---|---|
+| `api_url` | `franklyn.htl-leonding.ac.at/api` | Franklyn API endpoint |
+| `oidc_url` | `https://auth.htl-leonding.ac.at` | OpenID Connect server |
+| `oidc_realm` | `franklyn` | OIDC realm |
+| `oidc_client_id` | `sentinel` | OIDC client ID |
+| `oidc_scopes` | `openid` | OIDC scopes (space-separated) |
+
+## Load Order
+
+Later entries override earlier ones:
+
+1. Embedded defaults (compiled into the binary)
+2. System-level config file
+3. User-level config file
+4. Environment variables
+
+## Environment Variable Overrides
+
+Set environment variables at startup for a systemd service, Docker container, or any other managed environment to enforce configuration without touching user files.
+
+All config keys map to `FRANKLYN_<KEY>` in uppercase:
+
+```shell
+FRANKLYN_API_URL=yourserver.example.com/api
+FRANKLYN_OIDC_URL=https://auth.yourserver.example.com
+FRANKLYN_OIDC_REALM=yourrealm
+FRANKLYN_OIDC_CLIENT_ID=yourclient
+FRANKLYN_OIDC_SCOPES=openid
+```
+
+## Notes
+
+- Configuration is loaded once at startup. Changes to config files or environment variables require a restart.
+- Config files must be valid TOML.

--- a/hugo/content/guide/students/_index.md
+++ b/hugo/content/guide/students/_index.md
@@ -1,76 +1,10 @@
 ---
-title: Installation - Student
-description: Install Franklyn Sentinel on your computer
+title: Student Guide
+description: Install and set up Franklyn Sentinel for your exam
 weight: 10
 ---
 
-## Binaries
+Franklyn Sentinel runs on your computer during exams and streams your screen to your teacher's monitoring dashboard.
 
-You can download the Franklyn Sentinel binaries directly from the [Releases](https://github.com/2526-4ahitm-itp/2526-4ahitm-franklyn/releases).
-
-## Ubuntu (24.05+) / Debian (12+)
-
-Add the Franklyn APT repository to install Franklyn Sentinel.
-
-```shell
-curl -fsSL https://franklyn.htl-leonding.ac.at/repo/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/franklyn.gpg
-echo "deb [signed-by=/etc/apt/keyrings/franklyn.gpg] https://franklyn.htl-leonding.ac.at/repo stable main" | sudo tee /etc/apt/sources.list.d/franklyn.list
-sudo apt update
-```
-
-Then you can install `franklyn-sentinel`.
-
-```shell
-sudo apt install franklyn-sentinel
-```
-
-<details>
-<summary>Development version</summary>
-
-To install the development version instead:
-
-```shell
-curl -fsSL https://franklyn.htl-leonding.ac.at/repo/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/franklyn.gpg
-echo "deb [signed-by=/etc/apt/keyrings/franklyn.gpg] https://franklyn.htl-leonding.ac.at/repo dev main" | sudo tee /etc/apt/sources.list.d/franklyn.list
-sudo apt update
-sudo apt install franklyn-sentinel
-```
-
-</details>
-
-## nix
-put this into your flake.nix:
-```
-{
-  inputs = {
-
-    franklyn = {
-      url = "github:hyprwm/hyprland-plugins";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    # ...
-  }
-}
-
-
-# anwenden in nixos
-environment.systemPackages = [
-	inputs.franklyn.packages.${system}.franklyn-sentinel
-]
-```
-
-
-
-## Windows
-
-Download the newest available windows portable from our [Releases](https://github.com/2526-4ahitm-itp/2526-4ahitm-franklyn/releases).
-Then unzip the directory and navigate to it in a terminal.
-```shell
-cd Downloads/franklyn-sentinel-[VERSION]-x86_64-windows-portable
-```
-You can now execute franklyn.exe in the terminal.
-```shell
-franklyn.exe
-```
-**To ensure sentinel works, DO NOT double-click franklyn.exe, instead open a terminal and execute franklyn.exe**
+- [Installation](installation): install Franklyn Sentinel on your computer
+- [Setup](setup): configure which server to connect to and join an exam

--- a/hugo/content/guide/students/installation.md
+++ b/hugo/content/guide/students/installation.md
@@ -1,0 +1,76 @@
+---
+title: Installation
+description: Install Franklyn Sentinel on your computer
+weight: 10
+---
+
+## Binaries
+
+You can download the Franklyn Sentinel binaries directly from the [Releases](https://github.com/2526-4ahitm-itp/2526-4ahitm-franklyn/releases).
+
+## Ubuntu (24.05+) / Debian (12+)
+
+Add the Franklyn APT repository to install Franklyn Sentinel.
+
+```shell
+curl -fsSL https://franklyn.htl-leonding.ac.at/repo/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/franklyn.gpg
+echo "deb [signed-by=/etc/apt/keyrings/franklyn.gpg] https://franklyn.htl-leonding.ac.at/repo stable main" | sudo tee /etc/apt/sources.list.d/franklyn.list
+sudo apt update
+```
+
+Then you can install `franklyn-sentinel`.
+
+```shell
+sudo apt install franklyn-sentinel
+```
+
+<details>
+<summary>Development version</summary>
+
+To install the development version instead:
+
+```shell
+curl -fsSL https://franklyn.htl-leonding.ac.at/repo/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/franklyn.gpg
+echo "deb [signed-by=/etc/apt/keyrings/franklyn.gpg] https://franklyn.htl-leonding.ac.at/repo dev main" | sudo tee /etc/apt/sources.list.d/franklyn.list
+sudo apt update
+sudo apt install franklyn-sentinel
+```
+
+</details>
+
+## nix
+put this into your flake.nix:
+```
+{
+  inputs = {
+
+    franklyn = {
+      url = "github:hyprwm/hyprland-plugins";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # ...
+  }
+}
+
+
+# anwenden in nixos
+environment.systemPackages = [
+	inputs.franklyn.packages.${system}.franklyn-sentinel
+]
+```
+
+
+
+## Windows
+
+Download the newest available windows portable from our [Releases](https://github.com/2526-4ahitm-itp/2526-4ahitm-franklyn/releases).
+Then unzip the directory and navigate to it in a terminal.
+```shell
+cd Downloads/franklyn-sentinel-[VERSION]-x86_64-windows-portable
+```
+You can now execute franklyn.exe in the terminal.
+```shell
+franklyn.exe
+```
+**To ensure sentinel works, DO NOT double-click franklyn.exe, instead open a terminal and execute franklyn.exe**

--- a/hugo/content/guide/students/installation.md
+++ b/hugo/content/guide/students/installation.md
@@ -38,26 +38,105 @@ sudo apt install franklyn-sentinel
 
 </details>
 
-## nix
-put this into your flake.nix:
+## openSUSE Tumbleweed
+
+Install Franklyn Sentinel via the [openSUSE Open Build Service](https://software.opensuse.org/download.html?project=home%3Afranklyn&package=franklyn).
+
+Add the repository and install the package:
+
+```shell
+sudo zypper addrepo https://download.opensuse.org/repositories/home:franklyn/openSUSE_Tumbleweed/home:franklyn.repo
+sudo zypper refresh
+sudo zypper install franklyn
 ```
+
+## Nix
+
+Franklyn Sentinel is available as a Nix flake package (`franklyn-sentinel`).
+
+### Binary Cache (Cachix)
+
+Add the Franklyn Cachix cache to avoid rebuilding from source.
+
+**NixOS** — add to your configuration:
+
+```nix
+nix.settings = {
+  substituters = [ "https://franklyn.cachix.org" ];
+  trusted-public-keys = [
+    "franklyn.cachix.org-1:rvchIepdAmB8uOOc1dA7rxhncnDB0LfrFrYb+BhiA4M="
+  ];
+};
+```
+
+**Non-NixOS** — add to `/etc/nix/nix.conf` or `~/.config/nix/nix.conf`:
+
+```
+substituters = https://cache.nixos.org https://franklyn.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= franklyn.cachix.org-1:rvchIepdAmB8uOOc1dA7rxhncnDB0LfrFrYb+BhiA4M=
+```
+
+Or install `cachix` and run:
+
+```shell
+cachix use franklyn
+```
+
+### NixOS (flakes)
+
+Add the Franklyn flake input to your `flake.nix`:
+
+```nix
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     franklyn = {
-      url = "github:hyprwm/hyprland-plugins";
+      url = "github:2526-4ahitm-itp/2526-4ahitm-franklyn";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # ...
-  }
+  };
+
+  outputs = { nixpkgs, franklyn, ... }: {
+    nixosConfigurations.your-host = nixpkgs.lib.nixosSystem {
+      modules = [
+        {
+          environment.systemPackages = [
+            franklyn.packages.${system}.franklyn-sentinel
+          ];
+        }
+      ];
+    };
+  };
 }
+```
 
+### Home Manager
 
-# anwenden in nixos
-environment.systemPackages = [
-	inputs.franklyn.packages.${system}.franklyn-sentinel
-]
+Add to your Home Manager configuration:
+
+```nix
+{ inputs, pkgs, system, ... }: {
+  home.packages = [
+    inputs.franklyn.packages.${system}.franklyn-sentinel
+  ];
+}
+```
+
+### Without NixOS (nix profile)
+
+Install into your user profile with:
+
+```shell
+nix profile install github:2526-4ahitm-itp/2526-4ahitm-franklyn#franklyn-sentinel
+```
+
+### Run without installing
+
+```shell
+nix run github:2526-4ahitm-itp/2526-4ahitm-franklyn#franklyn-sentinel
 ```
 
 

--- a/hugo/content/guide/students/setup.md
+++ b/hugo/content/guide/students/setup.md
@@ -1,0 +1,27 @@
+---
+title: Setup
+description: Configure Franklyn Sentinel and join an exam
+weight: 20
+---
+
+## Configure the Server
+
+> If your teacher is using the default server (`franklyn.htl-leonding.ac.at`), skip this step.
+
+If your exam runs on a different server, enter the following in the terminal to set the server address once before joining, just like configuring your git username and email at the start of an exam.
+
+```shell
+franklyn config set api_url "franklyn3.htl-leonding.ac.at/api"
+```
+
+Replace `franklyn3.htl-leonding.ac.at` with the server your teacher specifies.
+
+## Join the Exam
+
+Enter the following in the terminal to join the exam with the PIN your teacher provides:
+
+```shell
+franklyn join <pin>
+```
+
+Example: `franklyn join 1234`

--- a/hugo/content/guide/teachers/_index.md
+++ b/hugo/content/guide/teachers/_index.md
@@ -1,9 +1,11 @@
 ---
-title: Usage - Teacher
+title: Teacher Guide
 description: Use Franklyn as a teacher
-weight: 10
+weight: 20
 ---
 
-## Access Franklyn Proctor
-Go to ```franklyn.htl-leonding.ac.at/proctor``` or click "Proctor" on the top right navigation bar, then
-enter your teacher login credentials and create or enter your exam. You can now start monitoring your students
+Use Franklyn to monitor your students' screens during exams in real time.
+
+- [Proctor](proctor): access and monitor exams
+- [Running an Exam](running-an-exam): start an exam and manage participants
+- [Preparing Students](preparing-students): help students get set up before the exam

--- a/hugo/content/guide/teachers/preparing-students.md
+++ b/hugo/content/guide/teachers/preparing-students.md
@@ -1,0 +1,31 @@
+---
+title: Preparing Students
+description: Help students get set up with Franklyn Sentinel before the exam
+weight: 30
+---
+
+Students need to have Franklyn Sentinel installed before the exam. If you are running your own server, they also need to configure which server to connect to.
+
+If you are unsure which server you are connected to, you can look at the URL in the browser when on the proctor site.
+
+For example if you see
+`https://franklyn3.htl-leonding.ac.at/proctor/exams/`
+
+then the URL for students will be:
+`franklyn3.htl-leonding.ac.at/api`
+
+---
+
+**Franklyn Setup**
+
+Enter the following in the terminal to configure which server to connect to (skip if using `franklyn.htl-leonding.ac.at`):
+
+```shell
+franklyn config set api_url "franklyn3.htl-leonding.ac.at/api"
+```
+
+Enter the following in the terminal to join the exam with the PIN provided by your teacher:
+
+```shell
+franklyn join <pin>
+```

--- a/hugo/content/guide/teachers/proctor.md
+++ b/hugo/content/guide/teachers/proctor.md
@@ -1,0 +1,9 @@
+---
+title: Proctor
+description: Access and monitor exams with Franklyn Proctor
+weight: 10
+---
+
+## Access Franklyn Proctor
+
+Go to `franklyn.htl-leonding.ac.at/proctor` or click "Proctor" in the top right navigation bar, then enter your teacher login credentials and create or enter your exam. You can now start monitoring your students.

--- a/hugo/content/guide/teachers/running-an-exam.md
+++ b/hugo/content/guide/teachers/running-an-exam.md
@@ -1,0 +1,18 @@
+---
+title: Running an Exam
+description: Start an exam and monitor participants
+weight: 20
+---
+
+## Starting an Exam
+
+1. Log in to Franklyn Proctor at `franklyn.htl-leonding.ac.at/proctor`.
+2. Create a new exam or select an existing one, then start it.
+3. A PIN is displayed. Share it with your students so they can join.
+
+## Monitoring
+
+Once students have joined, you can monitor them in the dashboard:
+
+- **Overview**: a grid of all active student screens at a glance
+- **Detail view**: click any student to expand their screen for a closer look

--- a/sentinel/src/config.rs
+++ b/sentinel/src/config.rs
@@ -8,6 +8,8 @@ use crate::ConfigAction;
 
 pub static CONFIG: LazyLock<AppConfig> = LazyLock::new(AppConfig::load);
 
+// When adding a new config field, document it in:
+// hugo/content/guide/administrators/sentinel-configuration.md
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppConfig {
     pub api_url: String,


### PR DESCRIPTION
## Summary

Adds a structured guide section for all three audiences: students, teachers, and administrators.

- Students get an installation page (existing content moved) and a new setup page covering server configuration and joining an exam
- Teachers get a landing page with subpages for Proctor access, running an exam, and preparing students (including a ready-to-paste exam specification snippet and a tip for identifying the correct server URL from the Proctor address)
- Administrators get a Sentinel configuration reference covering system- and user-level config file paths per OS, all config keys and defaults, load order, and environment variable overrides
- Front page gets a neutral "Prepare an Exam" button linking directly to the preparing-students page
- `AppConfig` in `sentinel/src/config.rs` gets a doc comment pointing to the documentation file so new fields don't get missed
- Installation guide updated: openSUSE Tumbleweed section added (via OBS), Nix section rewritten with correct flake URL, Cachix binary cache config, Home Manager, `nix profile install`, and `nix run` variants

Related: #197

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

## How was AI used here?

- [x] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [ ] Chat
- [ ] Other:

**How was it used?**
Used Claude Code to draft and structure all documentation pages. Content, wording, and corrections were reviewed and adjusted manually.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [x] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [x] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)