### PR TITLE
fix(cicd): make caddy route /proctor and /proctor/* to the proctor

### DIFF
--- a/cicd/compose/Caddyfile
+++ b/cicd/compose/Caddyfile
@@ -3,15 +3,28 @@
 }
 
 franklyn.htl-leonding.ac.at {
-	handle /api/* {
+
+	@api { 
+		path /api
+		path /api/*
+	}
+	handle @api {
 		reverse_proxy franklyn-server:8080
 	}
 
-	handle /proctor/* {
+	@proctor {
+		path /proctor
+		path /proctor/*
+	}
+	handle @proctor {
 		reverse_proxy franklyn-proctor:80
 	}
 
-	handle /repo/api/* {
+	@repo_api {
+		path /repo/api
+		path /repo/api/*
+	}
+	handle @repo_api {
 		basic_auth {
 			{$APTLY_USER} {$APTLY_HASH}
 		}
@@ -19,7 +32,11 @@ franklyn.htl-leonding.ac.at {
 		reverse_proxy franklyn-aptly:8080
 	}
 
-	handle /repo/* {
+	@repo {
+		path /repo
+		path /repo/*
+	}
+	handle @repo {
 		uri strip_prefix /repo
 		reverse_proxy franklyn-aptly:8081
 	}

--- a/cicd/compose/Caddyfile.dev
+++ b/cicd/compose/Caddyfile.dev
@@ -1,9 +1,17 @@
 :80 {
-	handle /api/* {
+	@api {
+		path /api
+		path /api/*
+	}
+	handle @api {
 		reverse_proxy franklyn-server:8080
 	}
 
-	handle /proctor/* {
+	@proctor {
+		path /proctor
+		path /proctor/*
+	}
+	handle @proctor {
 		reverse_proxy franklyn-proctor:80
 	}
 


### PR DESCRIPTION
## Summary

This fixes an issue where /proctor would actually go to hugo where hugo then would redirect to /proctor/ which would then be finally routed to the actual proctor. This was unintended behaviour which caused this bug after hugo implemented multi language support.

This was tested on the franklyn3 staging server.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [ ] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [X] Chat
- [ ] Other:

**How was it used?**

Researching the cause of the symptoms that where observed.

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [X] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
