### PR TITLE
feat(sentinel-install): preflight host requirement checks

### DIFF
--- a/hugo/static/scripts/sentinel-install.maintenance.md
+++ b/hugo/static/scripts/sentinel-install.maintenance.md
@@ -49,11 +49,12 @@ Every row is a spec requirement with the code that satisfies it. After any chang
 | **Non-interactivity** | No `read` from stdin anywhere (stdin is the piped script). The only `read` is from a file. All input via flags/env; safe non-interactive defaults. Any unavoidable prompt reads `/dev/tty` gated by `[ -t 0 ]`. | `parse_args`, absence of stdin `read` |
 | **Concurrency** | FD-based `flock` around **all** mutation (install, update, uninstall); kernel releases on crash. No `[ -f lockfile ]` race check. | `acquire_lock`, `release_lock` |
 | **Rootless constraints** | No `sudo` anywhere (only in doc/error strings). `$HOME` unset/not-dir/unwritable aborts clearly. `uname -m`/`-s` normalized (`amd64`→`x86_64`, `arm64`→`aarch64`). | `check_home`, `get_architecture` |
+| **Preflight host requirements** | Before download, glibc floor checked (`getconf GNU_LIBC_VERSION` → `ldd --version` fallback); detectably `< 2.34` aborts **pre-download** (exit 66); undetectable warns + continues. GStreamer **not** checked (bundled in portable tree). PipeWire warned (never fatal) only on a Wayland session when absent. `--skip-checks` / `FRANKLYN_SENTINEL_SKIP_CHECKS` bypasses all checks. No-exec; install/update only, never uninstall. | `check_requirements`, `detect_glibc_version`, `version_ge`, `session_is_wayland`, `have_pipewire` |
 | **Uninstall** | Removes **exactly** the manifest set (no guessed globs); strips the env-snippet source line from rc files (rc files are NOT manifested — never delete a whole `.bashrc`); refreshes desktop/icon caches; final `rm -rf` of the data dir tail. | `do_uninstall`, `remove_manifest_paths`, `remove_source_line` |
 | **Baseline shell hygiene** | `set -euo pipefail`; every expansion quoted (shellcheck clean); `trap cleanup EXIT INT TERM` removes temp/staging **and** releases the lock FD; every failure path exits non-zero per the exit-code table. | header, `cleanup`, `trap` |
 
 **Exit-code table (keep stable; document any addition in the script header and spec):**
-- `0` success · `1` general failure (network/checksum/extract/fs) · `64` usage error (bad flag / missing arg) · `65` refused — managed by a system package channel.
+- `0` success · `1` general failure (network/checksum/extract/fs) · `64` usage error (bad flag / missing arg) · `65` refused — managed by a system package channel · `66` host runtime requirement unmet (glibc below the 2.34 floor; overridable with `--skip-checks`).
 
 ---
 

--- a/hugo/static/scripts/sentinel-install.md
+++ b/hugo/static/scripts/sentinel-install.md
@@ -48,6 +48,13 @@ Read this before writing, reviewing, or modifying `sentinel-install.sh`. The ins
 - All paths live under `$HOME` / XDG dirs (`~/.local/bin`, `~/.local/share/...`). Fail immediately and clearly if `$HOME` itself isn't writable.
 - Normalize `uname -m` / `uname -s` variants (`aarch64` vs `arm64`, `x86_64` vs `amd64`) — never rely on a single string match.
 
+## Preflight host requirements
+- Before downloading, verify the host can actually run the installed (portable) binary. Requirements are derived from `sentinel/resources/README.portable.txt` (canonical) and `sentinel/Cargo.toml`; re-derive only if the artifact changes.
+- **glibc ≥ 2.34 (required).** The portable tarball bundles the app's own libraries (`lib/`, RUNPATH `$ORIGIN/../lib`) but still loads through the **host's** `ld-linux` + glibc, so an older glibc cannot run it. Detect via `getconf GNU_LIBC_VERSION`, fall back to `ldd --version`. If the host glibc is **detectably** older than 2.34, abort **before download** with exit code `66` and host guidance. If the version is undetectable (e.g. musl, no `getconf`/`ldd`), warn and continue — the `--version` smoke test remains the authoritative runnability gate.
+- **GStreamer is bundled** in the portable tree (`lib/`, `GSTREAMER_LICENSE`) and is therefore **not** a host requirement — do not check for a system GStreamer. (Only the non-portable `dist`/deb/rpm variants depend on system GStreamer; this installer never ships those.)
+- **PipeWire (conditional, advisory).** Needed only for Wayland screen capture (`ashpd` screencast portal); X11 sessions need nothing extra. If the session is Wayland (`XDG_SESSION_TYPE=wayland` or `WAYLAND_DISPLAY` set) and PipeWire is absent, warn — never fail.
+- Provide a non-interactive override: `--skip-checks` / `FRANKLYN_SENTINEL_SKIP_CHECKS` skips all preflight checks (escape hatch for a false negative). Checks run on install and update only, never on uninstall, and never exec the binary (no-exec — fully testable locally).
+
 ## Uninstall
 - Ship a way to reverse the install (flag or separate script).
 - Track a manifest of every path the installer wrote, so uninstall removes exactly that — not a guessed glob.

--- a/hugo/static/scripts/sentinel-install.sh
+++ b/hugo/static/scripts/sentinel-install.sh
@@ -18,6 +18,8 @@
 #   64  usage error — bad flag or missing argument            [EX_USAGE]
 #   65  refused — franklyn is managed by a system package channel
 #       (apt/dpkg, rpm, pacman); update through that channel  [EX_DATAERR]
+#   66  host runtime requirement unmet — glibc older than the
+#       portable build's 2.34 floor; override with --skip-checks  [EX_NOINPUT]
 
 set -euo pipefail
 
@@ -68,6 +70,12 @@ readonly LOCK_FILE="$INSTALL_DATA_DIR/.lock"
 readonly CURL_CONNECT_TIMEOUT=10
 readonly CURL_RETRY=3
 
+# Minimum host glibc the portable build can load. The tarball bundles the app's
+# own libs (RUNPATH '$ORIGIN/../lib') but still resolves the interpreter + libc
+# from the host, so an older glibc cannot run it. Sourced from the bundled
+# README (sentinel/resources/README.portable.txt); bump only if that changes.
+readonly MIN_GLIBC_VERSION="2.34"
+
 # ----------------------------------------------------------------------------
 # Mutable run state (set by parse_args / platform detection)
 # ----------------------------------------------------------------------------
@@ -78,6 +86,8 @@ ACTION="install"
 OPT_VERSION="${FRANKLYN_SENTINEL_VERSION:-}"
 # Optional binary-dir override; empty => XDG_BIN_HOME. Consumed in Phase 3/4.
 OPT_INSTALL_DIR=""
+# Skip preflight host-requirement checks when set (flag or env escape hatch).
+OPT_SKIP_CHECKS="${FRANKLYN_SENTINEL_SKIP_CHECKS:-}"
 # Normalized asset arch token: x86_64 | aarch64.
 ARCH=""
 # Resolved version token (no leading 'v') and matching git tag (with 'v').
@@ -234,10 +244,13 @@ OPTIONS:
     --uninstall          Remove a previous installation.
     --install-dir <DIR>  Override the binary install directory
                          (default: $XDG_BIN_HOME).
+    --skip-checks        Skip preflight host-requirement checks
+                         (glibc floor, PipeWire).
     -h, --help           Show this help and exit.
 
 ENVIRONMENT:
     FRANKLYN_SENTINEL_VERSION    Same as --version.
+    FRANKLYN_SENTINEL_SKIP_CHECKS  Same as --skip-checks (any non-empty value).
     XDG_BIN_HOME / XDG_DATA_HOME / XDG_CONFIG_HOME    Standard XDG overrides.
     NO_COLOR                     Disable colored output.
 
@@ -276,6 +289,9 @@ parse_args() {
             --install-dir=*)
                 OPT_INSTALL_DIR="${1#*=}"
                 ;;
+            --skip-checks)
+                OPT_SKIP_CHECKS=1
+                ;;
             *)
                 err "unknown option: '$1' (try --help)" 64
                 ;;
@@ -310,6 +326,96 @@ get_architecture() {
         aarch64 | arm64) ARCH="aarch64" ;;
         *) err "unsupported architecture: '$machine' (supported: x86_64, aarch64)" ;;
     esac
+}
+
+# ----------------------------------------------------------------------------
+# Preflight host requirements
+#
+# Verify the host can actually run the portable build before we spend bandwidth
+# downloading it. Requirements derive from sentinel/resources/README.portable.txt
+# (canonical): glibc >= 2.34 (hard — the host's loader/libc back the bundled
+# tree) and, for Wayland screen capture only, PipeWire (advisory). GStreamer is
+# bundled in the tarball, so it is deliberately NOT checked. All checks are
+# no-exec; the binary's own --version smoke test stays the authoritative gate.
+# ----------------------------------------------------------------------------
+
+# detect_glibc_version — print the host glibc "MAJOR.MINOR", or nothing if it
+# cannot be determined (e.g. musl, or neither getconf nor ldd present).
+detect_glibc_version() {
+    local out
+    if check_cmd getconf; then
+        # e.g. "glibc 2.35"
+        out="$(getconf GNU_LIBC_VERSION 2>/dev/null)" || out=""
+        if [[ "$out" =~ ([0-9]+\.[0-9]+) ]]; then
+            printf '%s\n' "${BASH_REMATCH[1]}"
+            return 0
+        fi
+    fi
+    if check_cmd ldd; then
+        # GNU ldd prints e.g. "ldd (GNU libc) 2.35" on the first line; musl ldd
+        # prints no glibc version, so the regex simply does not match there.
+        out="$(ldd --version 2>/dev/null | head -n1)" || out=""
+        if [[ "$out" =~ ([0-9]+\.[0-9]+) ]]; then
+            printf '%s\n' "${BASH_REMATCH[1]}"
+            return 0
+        fi
+    fi
+    return 0
+}
+
+# version_ge A B — true (0) if dotted-numeric version A is >= B. Uses `sort -V`
+# so 2.34 >= 2.9 compares correctly (component-wise, not lexically).
+version_ge() {
+    [ "$1" = "$2" ] && return 0
+    local lower
+    lower="$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)"
+    [ "$lower" = "$2" ]
+}
+
+# session_is_wayland — true if the current desktop session looks like Wayland.
+session_is_wayland() {
+    [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]
+}
+
+# have_pipewire — true if a PipeWire runtime appears present on the host.
+have_pipewire() {
+    check_cmd pipewire && return 0
+    check_cmd pw-cli && return 0
+    if check_cmd ldconfig; then
+        ldconfig -p 2>/dev/null | grep -q 'libpipewire-0\.3\.so' && return 0
+    fi
+    return 1
+}
+
+# check_requirements — preflight the host against the portable build's runtime
+# needs. Fatal only on a detectable glibc below the floor (exit 66); an
+# undetectable glibc warns and proceeds; PipeWire is advisory and only on
+# Wayland. Skipped entirely by --skip-checks / FRANKLYN_SENTINEL_SKIP_CHECKS.
+check_requirements() {
+    if [ -n "$OPT_SKIP_CHECKS" ]; then
+        warn "skipping host requirement checks (--skip-checks)"
+        return 0
+    fi
+
+    say "checking host requirements..."
+
+    local glibc
+    glibc="$(detect_glibc_version)"
+    if [ -n "$glibc" ]; then
+        if version_ge "$glibc" "$MIN_GLIBC_VERSION"; then
+            say "  glibc $glibc (>= $MIN_GLIBC_VERSION) OK"
+        else
+            err "host glibc $glibc is older than the required $MIN_GLIBC_VERSION; the portable build cannot run here (need e.g. Ubuntu 22.04+, Debian 12+, Fedora 35+, RHEL/Rocky/Alma 9+). Re-run with --skip-checks to override." 66
+        fi
+    else
+        warn "could not determine the host glibc version; the portable build needs glibc >= $MIN_GLIBC_VERSION (the --version smoke test will catch an incompatible host)"
+    fi
+
+    # PipeWire is only needed for Wayland screen capture; X11 needs nothing
+    # extra, so warn rather than fail and only on a Wayland session.
+    if session_is_wayland && ! have_pipewire; then
+        warn "Wayland session detected but PipeWire was not found; Wayland screen capture needs PipeWire on the host (X11 capture is unaffected)"
+    fi
 }
 
 # ----------------------------------------------------------------------------
@@ -967,6 +1073,11 @@ main() {
         do_uninstall
         return 0
     fi
+
+    # Preflight host requirements before any network/disk work, so an
+    # unsupported host fails fast with clear guidance, not a cryptic loader
+    # error after the download.
+    check_requirements
 
     # Serialize all install/update mutations before touching anything on disk.
     acquire_lock


### PR DESCRIPTION
## Summary

Adds **preflight host-requirement checks** to the rootless `sentinel-install.sh` installer. Before downloading, the installer now verifies the host can actually run the portable build, so an unsupported host fails fast with clear guidance instead of a cryptic dynamic-loader error after the download. Requirements are derived from the portable build's own runtime doc (`sentinel/resources/README.portable.txt`):

- **glibc ≥ 2.34** (hard floor) — detected via `getconf GNU_LIBC_VERSION` with an `ldd --version` fallback. A detectably older glibc aborts **pre-download** with new exit code `66` and host guidance; an undetectable version (e.g. musl) warns and defers to the existing `--version` smoke test.
- **PipeWire** — advisory only: warned when the session is Wayland and PipeWire is absent (X11 capture needs nothing extra).
- **GStreamer is intentionally not checked** — it is bundled inside the portable tarball, so a host check would false-fail working machines.

Override with `--skip-checks` / `FRANKLYN_SENTINEL_SKIP_CHECKS`. Checks run on install/update only, never uninstall, and never exec the binary.

Per the installer's protected-file process, the spec (`sentinel-install.md`) and maintenance companion (`sentinel-install.maintenance.md`, regression row + exit-66 entry) were updated first, then the script.

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [x] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [x] Chat
- [ ] Other:

**How was it used?**
Built with Claude Code following the spec-first process in `sentinel-install.maintenance.md`: derived the requirements from the sentinel source, updated the spec first, then the script, then ran the §0 verification protocol.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have run the tests using the dedicated test scripts
- [x] I have updated the documentation (if applicable)
- [x] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [x] **Sentinel:** §0 verification — `bash -n` + shellcheck clean, 13/13 no-exec unit tests. Run-path confirmed on a real aarch64 glibc host: fresh install, idempotent re-run, `--skip-checks`, and `--uninstall` all exit 0; preflight prints `glibc 2.39 (>= 2.34) OK`.
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
