### PR TITLE
docs: automatic redirect for languages

### DIFF
--- a/hugo/layouts/alias.html
+++ b/hugo/layouts/alias.html
@@ -1,0 +1,55 @@
+{{- /*
+  Override of Hugo's built-in alias.html.
+
+  Hugo renders the site root ("/") through this template when
+  defaultContentLanguageInSubdir is true, redirecting to the default
+  language's home page. We extend that redirect to also honor:
+  1. a language the user explicitly picked via the switcher (saved to
+     localStorage by layouts/partials/custom/head-end.html), or
+  2. failing that, the browser's preferred language (navigator.languages).
+  Falls back to the original default-language redirect with no JS.
+*/ -}}
+<!DOCTYPE html>
+<html lang="{{ .Lang }}">
+  <head>
+    <title>{{ .Permalink }}</title>
+    <link rel="canonical" href="{{ .Permalink }}">
+    <meta charset="utf-8">
+    {{- $altHomes := dict -}}
+    {{- range site.Sites -}}
+      {{- $altHomes = merge $altHomes (dict .Language.Lang .Home.RelPermalink) -}}
+    {{- end }}
+    {{- /* Only remap across languages when this alias is itself a redirect
+           to a language's home page (e.g. the multilingual "/" root).
+           Other aliases (e.g. pagination) must keep their own target. */ -}}
+    {{- if and hugo.IsMultilingual (eq .RelPermalink (index $altHomes .Lang)) }}
+      <script>
+        (function () {
+          var altHomes = {{ $altHomes | jsonify | safeJS }};
+          var target = {{ .RelPermalink | jsonify | safeJS }};
+          try {
+            var saved = localStorage.getItem("franklyn-lang");
+            if (saved && altHomes[saved]) {
+              target = altHomes[saved];
+            } else if (!saved) {
+              var prefs = navigator.languages || [navigator.language || ""];
+              for (var i = 0; i < prefs.length; i++) {
+                var code = (prefs[i] || "").slice(0, 2).toLowerCase();
+                if (altHomes[code]) {
+                  target = altHomes[code];
+                  break;
+                }
+              }
+            }
+          } catch (e) {}
+          window.location.replace(target);
+        })();
+      </script>
+      <noscript>
+        <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+      </noscript>
+    {{- else }}
+      <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+    {{- end }}
+  </head>
+</html>

--- a/hugo/layouts/partials/custom/head-end.html
+++ b/hugo/layouts/partials/custom/head-end.html
@@ -1,0 +1,18 @@
+{{- if hugo.IsMultilingual -}}
+<script>
+  (function () {
+    // Remember an explicit language choice made via the language switcher,
+    // so the root redirect (layouts/alias.html) can honor it on later visits
+    // instead of re-detecting the browser locale every time.
+    document.addEventListener("click", function (event) {
+      var link = event.target.closest(".hextra-language-options a[data-lang]");
+      if (!link) return;
+      try {
+        localStorage.setItem("franklyn-lang", link.getAttribute("data-lang"));
+      } catch (e) {
+        // localStorage unavailable (e.g. privacy mode) - navigation still works normally.
+      }
+    });
+  })();
+</script>
+{{- end -}}

--- a/hugo/layouts/partials/language-switch.html
+++ b/hugo/layouts/partials/language-switch.html
@@ -1,0 +1,58 @@
+{{/* Override of github.com/imfing/hextra layouts/_partials/language-switch.html */}}
+{{/* Adds data-lang to each option so client JS can remember the user's choice. */}}
+
+{{- $page := .context -}}
+{{- $iconName := .iconName | default "globe-alt" -}}
+{{- $iconHeight := .iconHeight | default 12 -}}
+{{- $location := .location -}}
+
+{{- $class := .class | default "hx:h-7 hx:px-2 hx:text-xs hx:text-gray-600 hx:transition-colors hx:dark:text-gray-400 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-primary-100/5 hx:dark:hover:text-gray-50" -}}
+
+{{- $grow := .grow -}}
+{{- $hideLabel := .hideLabel | default false -}}
+
+{{- $changeLanguage := (T "changeLanguage") | default "Change language" -}}
+
+{{- if hugo.IsMultilingual -}}
+  <div class="hx:flex hx:justify-items-start {{ if $grow }}hx:grow{{ end }}">
+    <button
+      title="{{ $changeLanguage }}"
+      data-state="closed"
+      data-location="{{ $location }}"
+      class="hextra-language-switcher hx:cursor-pointer hx:rounded-md hx:text-left hx:font-medium {{ $class }} hx:grow"
+      type="button"
+      aria-label="{{ $changeLanguage }}"
+      aria-expanded="false"
+      aria-haspopup="menu"
+    >
+      <div class="hx:flex hx:items-center hx:gap-2 hx:capitalize">
+        {{- partial "utils/icon" (dict "name" $iconName "attributes" (printf "height=%d" $iconHeight)) -}}
+        {{- if not $hideLabel }}<span>{{ site.Language.LanguageName }}</span>{{ end -}}
+      </div>
+    </button>
+    <ul
+      class="hextra-language-options hx:hidden hx:z-20 hx:max-h-64 hx:overflow-auto hx:rounded-lg hx:border hx:border-gray-200 hx:bg-white hx:p-1 hx:text-sm hx:shadow-lg hx:dark:border-neutral-700 hx:dark:bg-neutral-900"
+      style="position: fixed; inset: auto auto 0px 0px; margin: 0px; min-width: 100px;"
+      role="menu"
+    >
+      {{ range site.Languages }}
+        {{ $link := partial "utils/lang-link" (dict "lang" .Lang "context" $page) }}
+        <li role="none" class="hx:flex hx:flex-col">
+          <a
+            href="{{ $link }}"
+            data-lang="{{ .Lang }}"
+            role="menuitem"
+            class="hx:text-gray-700 hx:dark:text-gray-300 hx:hover:bg-gray-100 hx:hover:text-gray-900 hx:dark:hover:bg-neutral-800 hx:dark:hover:text-gray-100 hx:relative hx:cursor-pointer hx:whitespace-nowrap hx:rounded-sm hx:py-1.5 hx:transition-colors hx:ltr:pl-3 hx:ltr:pr-9 hx:rtl:pr-3 hx:rtl:pl-9"
+          >
+            {{- .LanguageName -}}
+            {{- if eq .LanguageName site.Language.LanguageName -}}
+              <span class="hx:absolute hx:inset-y-0 hx:flex hx:items-center hx:ltr:right-3 hx:rtl:left-3">
+                {{- partial "utils/icon" (dict "name" "check" "attributes" "height=1em width=1em") -}}
+              </span>
+            {{- end -}}
+          </a>
+        </li>
+      {{ end -}}
+    </ul>
+  </div>
+{{- end -}}


### PR DESCRIPTION
## Summary

With this fix, people get automatically redirected to the correct languages, that their device and browser is set to. Only german and english are available if the languages, if other languages are used they get automatically to english.

### How to test german
````
LANG=de_AT.UTF-8 LANGUAGE=de_AT LC_ALL=de_AT.UTF-8 chromium  http://localhost:1313/ 
````

### How to test english
````
LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 chromium --user-data-dir=/tmp/chrome-en3 http://localhost:1313/
````

Fixes #362 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [x] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [ ] Chat
- [ ] Other:

**How was it used?**
Used claude for helping to test functionality and create needed files

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [x] I have updated the documentation (if applicable)
- [ ] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [ ] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [x] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
