### PR TITLE
chore: add local caddy reverse proxy for tls on local dev

### DIFF
--- a/proctor/package.json
+++ b/proctor/package.json
@@ -8,7 +8,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",

--- a/server/docker/Caddyfile
+++ b/server/docker/Caddyfile
@@ -1,0 +1,23 @@
+localhost {
+    tls internal
+
+	@api { 
+		path /api
+		path /api/*
+	}
+	handle @api {
+		reverse_proxy host.docker.internal:5050
+	}
+
+	@proctor {
+		path /proctor
+		path /proctor/*
+	}
+	handle @proctor {
+		reverse_proxy host.docker.internal:5173
+	}
+
+	handle {
+		reverse_proxy host.docker.internal:1313
+	}
+}

--- a/server/docker/docker-compose.yaml
+++ b/server/docker/docker-compose.yaml
@@ -28,9 +28,24 @@ services:
     volumes:
       - franklyn-pgadmin4-servers:/var/lib/pgadmin
 
+  caddy:
+    image: caddy:latest
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "4433:443"
+      - "8080:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - franklyn-caddy-data:/data
+      - franklyn-caddy-config:/config
+
+
 volumes:
   franklyn-postgres-database:
   franklyn-pgadmin4-servers:
+  franklyn-caddy-data:
+  franklyn-caddy-config:
 
 
 networks:


### PR DESCRIPTION


## Summary

This PR lays the groundword for the local dev reverse proxy so tls can be used locally so no non-tls way has to be implemented in a client just for the sake of locally testing.

To make the reverse proxy work, all components have to bind to `0.0.0.0` and not just localhost. additionally, proctor must be started with `--base /proctor` and hugo with this command:

```shell
hugo serve \
  --bind 0.0.0.0 \
  --baseURL https://localhost:4433 \
  --appendPort=false \
  --liveReloadPort 4433
```

Related: #295 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [X] Other (please describe): Local developer experience improvement

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [ ] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [ ] Chat
- [ ] Other:

**How was it used?**
<!-- e.g. "Used Claude to draft the migration logic, reviewed and adjusted manually" -->

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [X] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [X] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
