### PR TITLE
feat(proctor): prompt when ad blocker blocks telemetry

### DIFF
--- a/proctor/src/App.vue
+++ b/proctor/src/App.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import NavComponent from './components/NavComponent.vue'
 import NoticeBanner from '@/components/notice/NoticeBanner.vue'
+import TelemetryBlockedDialog from '@/components/TelemetryBlockedDialog.vue'
 import { useResolvedTheme } from '@/services/theme'
 import { useCurrentUser } from '@/services/user'
 import { useNotices } from '@/services/notices'
 import { useDismissedNotices } from '@/services/dismissedNotices'
+import { useTelemetryBlockNotice } from '@/services/telemetryBlockNotice'
+import { detectTelemetryBlocked } from '@/services/telemetryBlock'
 import type { Notice, NoticeType } from '@/types/Notice'
 import { useI18n } from 'vue-i18n'
 import { toDate } from '@/lib/datetime'
@@ -70,6 +73,19 @@ watch(
   },
   { immediate: true },
 )
+
+// Telemetry blocked detection — surface a prompt when an ad blocker silently drops
+// Sentry events. Runs after mount so it never delays app boot, and is skipped once the
+// user has permanently dismissed it.
+const { dismissedForever, dismissForever } = useTelemetryBlockNotice()
+const showTelemetryBlocked = ref(false)
+
+onMounted(async () => {
+  if (dismissedForever.value) return
+  if ((await detectTelemetryBlocked()) === 'blocked') {
+    showTelemetryBlocked.value = true
+  }
+})
 </script>
 
 <template>
@@ -93,6 +109,10 @@ watch(
     <main class="app-main">
       <RouterView />
     </main>
+    <TelemetryBlockedDialog
+      v-model:open="showTelemetryBlocked"
+      @dismiss-forever="dismissForever"
+    />
   </div>
 </template>
 

--- a/proctor/src/components/TelemetryBlockedDialog.vue
+++ b/proctor/src/components/TelemetryBlockedDialog.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import UiDialog from './ui/Dialog.vue'
+import UiButton from './ui/Button.vue'
+import { detectTelemetryBlocked } from '@/services/telemetryBlock'
+
+defineOptions({
+  name: 'TelemetryBlockedDialog',
+})
+
+const open = defineModel<boolean>('open', { required: true })
+
+const emit = defineEmits<{
+  (e: 'dismiss-forever' | 'recheck-passed'): void
+}>()
+
+const { t } = useI18n()
+
+type RecheckState = 'idle' | 'still-blocked' | 'passed'
+
+const rechecking = ref(false)
+const recheckState = ref<RecheckState>('idle')
+
+function keepBlocker(): void {
+  emit('dismiss-forever')
+  open.value = false
+}
+
+async function iDisabledIt(): Promise<void> {
+  rechecking.value = true
+  recheckState.value = 'idle'
+  try {
+    const result = await detectTelemetryBlocked()
+    if (result === 'blocked') {
+      recheckState.value = 'still-blocked'
+      return
+    }
+    // 'ok' or 'offline' — telemetry is no longer being blocked; thank the user briefly.
+    recheckState.value = 'passed'
+    setTimeout(() => {
+      emit('recheck-passed')
+      open.value = false
+    }, 1200)
+  } finally {
+    rechecking.value = false
+  }
+}
+</script>
+
+<template>
+  <UiDialog v-model:open="open" :title="t('telemetryBlocked.title')">
+    <p class="dialog-description">{{ t('telemetryBlocked.body') }}</p>
+
+    <p v-if="recheckState === 'still-blocked'" class="recheck recheck-error" role="alert">
+      {{ t('telemetryBlocked.stillBlocked') }}
+    </p>
+    <p v-else-if="recheckState === 'passed'" class="recheck recheck-success" role="status">
+      {{ t('telemetryBlocked.nowWorking') }}
+    </p>
+
+    <div class="modal-actions">
+      <UiButton variant="secondary" :disabled="rechecking" @click="keepBlocker">
+        {{ t('telemetryBlocked.keepBlocker') }}
+      </UiButton>
+      <UiButton variant="primary" :loading="rechecking" @click="iDisabledIt">
+        {{ t('telemetryBlocked.iDisabledIt') }}
+      </UiButton>
+    </div>
+  </UiDialog>
+</template>
+
+<style scoped>
+.dialog-description {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: var(--space-4);
+}
+
+.recheck {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-4);
+}
+
+.recheck-error {
+  color: var(--error);
+  background: var(--alert-error-bg);
+}
+
+.recheck-success {
+  color: var(--success);
+  background: var(--alert-success-bg);
+}
+
+.modal-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  margin-top: var(--space-5);
+}
+</style>

--- a/proctor/src/locales/de.json
+++ b/proctor/src/locales/de.json
@@ -171,7 +171,7 @@
   },
   "telemetryBlocked": {
     "title": "Telemetrie wird blockiert",
-    "body": "Diese Seite sendet anonyme Fehler-Telemetrie, die uns hilft, Probleme zu finden und zu beheben. Eine Browser-Erweiterung (etwa ein Werbe- oder Tracking-Blocker) blockiert diese Anfragen. Wenn Sie uns unterstützen möchten, deaktivieren Sie Ihren Blocker bitte für diese Domain.",
+    "body": "Diese Seite sendet Fehler-Telemetrie, die uns hilft, Probleme zu finden und zu beheben. Eine Browser-Erweiterung (etwa ein Werbe- oder Tracking-Blocker) blockiert diese Anfragen. Wenn Sie uns unterstützen möchten, deaktivieren Sie Ihren Blocker bitte für diese Domain.",
     "keepBlocker": "Blocker behalten",
     "iDisabledIt": "Ich habe ihn deaktiviert",
     "stillBlocked": "Weiterhin blockiert. Stellen Sie sicher, dass Ihr Blocker für diese Domain deaktiviert ist, und versuchen Sie es erneut.",

--- a/proctor/src/locales/de.json
+++ b/proctor/src/locales/de.json
@@ -168,5 +168,13 @@
     "meta": {
       "na": "k. A."
     }
+  },
+  "telemetryBlocked": {
+    "title": "Telemetrie wird blockiert",
+    "body": "Diese Seite sendet anonyme Fehler-Telemetrie, die uns hilft, Probleme zu finden und zu beheben. Eine Browser-Erweiterung (etwa ein Werbe- oder Tracking-Blocker) blockiert diese Anfragen. Wenn Sie uns unterstützen möchten, deaktivieren Sie Ihren Blocker bitte für diese Domain.",
+    "keepBlocker": "Blocker behalten",
+    "iDisabledIt": "Ich habe ihn deaktiviert",
+    "stillBlocked": "Weiterhin blockiert. Stellen Sie sicher, dass Ihr Blocker für diese Domain deaktiviert ist, und versuchen Sie es erneut.",
+    "nowWorking": "Danke! Die Telemetrie funktioniert wieder."
   }
 }

--- a/proctor/src/locales/en.json
+++ b/proctor/src/locales/en.json
@@ -171,7 +171,7 @@
   },
   "telemetryBlocked": {
     "title": "Telemetry is being blocked",
-    "body": "This site sends anonymous error telemetry that helps us find and fix problems. A browser extension (such as an ad or tracking blocker) is blocking those requests. If you'd like to support us, please disable your blocker for this domain.",
+    "body": "This site sends error telemetry that helps us find and fix problems. A browser extension (such as an ad or tracking blocker) is blocking those requests. If you'd like to support us, please disable your blocker for this domain.",
     "keepBlocker": "Keep my blocker",
     "iDisabledIt": "I disabled it",
     "stillBlocked": "Still blocked. Make sure your blocker is disabled for this domain, then try again.",

--- a/proctor/src/locales/en.json
+++ b/proctor/src/locales/en.json
@@ -168,5 +168,13 @@
     "meta": {
       "na": "N/A"
     }
+  },
+  "telemetryBlocked": {
+    "title": "Telemetry is being blocked",
+    "body": "This site sends anonymous error telemetry that helps us find and fix problems. A browser extension (such as an ad or tracking blocker) is blocking those requests. If you'd like to support us, please disable your blocker for this domain.",
+    "keepBlocker": "Keep my blocker",
+    "iDisabledIt": "I disabled it",
+    "stillBlocked": "Still blocked. Make sure your blocker is disabled for this domain, then try again.",
+    "nowWorking": "Thank you! Telemetry is working again."
   }
 }

--- a/proctor/src/services/telemetry.ts
+++ b/proctor/src/services/telemetry.ts
@@ -4,7 +4,7 @@ import { getConfig } from '@/config'
 
 const DSN = 'https://e5c730457a1a476ba98daf19be4cae18@franklyn.htl-leonding.ac.at/glitchtip/2'
 
-function isEnabled(): boolean {
+export function isTelemetryEnabled(): boolean {
   // Never register telemetry during local development (bun run dev).
   if (import.meta.env.DEV) return false
   // Default off, opt-in via the runtime `telemetry` config flag.
@@ -12,7 +12,7 @@ function isEnabled(): boolean {
 }
 
 export function initTelemetry(app: App): void {
-  if (!isEnabled()) return
+  if (!isTelemetryEnabled()) return
 
   Sentry.init({
     app,
@@ -30,7 +30,7 @@ export interface TelemetryUser {
 }
 
 export function setTelemetryUser(user: TelemetryUser): void {
-  if (!isEnabled()) return
+  if (!isTelemetryEnabled()) return
 
   Sentry.setUser({
     id: user.id,

--- a/proctor/src/services/telemetryBlock.ts
+++ b/proctor/src/services/telemetryBlock.ts
@@ -1,0 +1,79 @@
+import * as Sentry from '@sentry/vue'
+import { isTelemetryEnabled } from '@/services/telemetry'
+
+export type TelemetryBlockResult = 'ok' | 'blocked' | 'offline'
+
+// Backend health endpoint (Quarkus SmallRye Health) — unauthenticated and proxied
+// like the rest of /api. Used as the control probe: if this is reachable but the
+// Sentry ingest host is not, the telemetry request was blocked (e.g. by an ad blocker)
+// rather than the network being down.
+const BACKEND_HEALTH_URL = '/api/q/health'
+
+/**
+ * Build the Sentry/Glitchtip envelope ingest URL from the configured DSN. The
+ * `sentry_key` query parameter is included on purpose: ad-blocker filter lists match the
+ * real envelope request by that pattern, so the probe must carry it to be blocked
+ * identically. A bare URL without the query string is NOT blocked and would give a false
+ * "reachable" result. Returns null when no usable DSN is configured.
+ */
+function ingestUrlFromDsn(): string | null {
+  const dsn = Sentry.getClient()?.getDsn()
+  if (!dsn?.host || !dsn.projectId || !dsn.publicKey) return null
+
+  const protocol = dsn.protocol || 'https'
+  const port = dsn.port ? `:${dsn.port}` : ''
+  const path = dsn.path ? `/${dsn.path}` : ''
+  const query = new URLSearchParams({
+    sentry_version: '7',
+    sentry_key: dsn.publicKey,
+    sentry_client: 'franklyn-proctor-blockcheck',
+  })
+  return `${protocol}://${dsn.host}${port}${path}/api/${dsn.projectId}/envelope/?${query}`
+}
+
+/**
+ * Probe the Sentry ingest endpoint, mirroring the real event request (POST + sentry_key
+ * query) so ad blockers treat it the same. `no-cors` means an opaque response resolves
+ * (server reached, even on 4xx/5xx) and only a transport-level failure — blocked by
+ * client, DNS, offline — rejects.
+ */
+async function isSentryReachable(url: string): Promise<boolean> {
+  try {
+    await fetch(url, { method: 'POST', mode: 'no-cors', cache: 'no-store', body: '' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function isReachable(url: string): Promise<boolean> {
+  try {
+    await fetch(url, { method: 'GET', mode: 'no-cors', cache: 'no-store' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Best-effort detection of telemetry being blocked.
+ *
+ * - `'ok'`      — telemetry disabled, no DSN, or the ingest host is reachable.
+ * - `'blocked'` — ingest host unreachable but the backend is up (server up ⇒ Sentry
+ *                 should be up too, so the request was blocked, e.g. by an ad blocker).
+ * - `'offline'` — both probes failed; treat as a general network problem, do not prompt.
+ *
+ * Note: a genuinely down Sentry server is reported as `'blocked'` by design.
+ */
+export async function detectTelemetryBlocked(): Promise<TelemetryBlockResult> {
+  if (!isTelemetryEnabled()) return 'ok'
+
+  const ingestUrl = ingestUrlFromDsn()
+  if (!ingestUrl) return 'ok'
+
+  if (await isSentryReachable(ingestUrl)) return 'ok'
+
+  if (navigator.onLine === false) return 'offline'
+
+  return (await isReachable(BACKEND_HEALTH_URL)) ? 'blocked' : 'offline'
+}

--- a/proctor/src/services/telemetryBlockNotice.ts
+++ b/proctor/src/services/telemetryBlockNotice.ts
@@ -1,0 +1,39 @@
+import { ref, type Ref } from 'vue'
+
+interface TelemetryBlockNoticeApi {
+  dismissedForever: Ref<boolean>
+  dismissForever: () => void
+}
+
+const STORAGE_KEY = 'franklyn.telemetry.blocker-dismissed'
+
+const dismissedForever = ref<boolean>(loadFromStorage())
+
+function loadFromStorage(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch (err) {
+    console.error('Failed to load telemetry blocker preference', err)
+    return false
+  }
+}
+
+function persist() {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(dismissedForever.value))
+  } catch (err) {
+    console.error('Failed to persist telemetry blocker preference', err)
+  }
+}
+
+export function useTelemetryBlockNotice(): TelemetryBlockNoticeApi {
+  function dismissForever() {
+    dismissedForever.value = true
+    persist()
+  }
+
+  return {
+    dismissedForever,
+    dismissForever,
+  }
+}


### PR DESCRIPTION
This is Stacked on top of #372 so review this after.

## Summary

This PR adds a little modal for if the user of proctor has an ad blocker installed, to please disable them on this domain in order to help us catch bugs.

### Testing

Locally switch the line 
```
  if (import.meta.env.DEV) return false
```
in `telemetry.ts:9` to return true, then telemetry is enabled in dev mode.

For this, the server has to be started.

Then open the browser, if ublock origin is enabled, sentry requests will be blocked while api requests to the server are not blocked and will prompt the popup.

Dismissing it by clicking "keep my blocker" will never show it again (browser storage).
Claiming to have disabled the blocker will retry again, dismissing if successfull and reprompting if not.

Related: #368 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## How was AI used here?

<!-- Did you use AI tools while working on this? Check all that apply. -->

- [X] Agentic Coding (claude code, codex, opencode)
  - [ ] Openspec was used to make changes
- [ ] Inline completion (Copilot, Supermaven, etc.)
- [ ] Chat
- [ ] Other:

**How was it used?**
Make plan, code plan.

## Checklist

- [x] I have performed a self-review of my code
- [X] I have run the tests using the dedicated test scripts
- [ ] I have updated the documentation (if applicable)
- [X] I have verified that my changes work correctly:
  - [ ] **Server (GraphQL API):** I have tested affected queries/mutations using the [Bruno](https://www.usebruno.com/) collection (`server/http/franklyn/`) or the GraphQL Dev UI (`/q/graphql-ui`) and confirmed correct responses
  - [ ] **Server (WebSocket):** If WebSocket behavior was changed, I have verified real-time communication between Sentinel and Proctor works as expected
  - [X] **Proctor (Frontend):** I have manually tested the affected UI in the browser, clicked through relevant flows, and confirmed the feature/fix works visually and functionally
  - [ ] **Sentinel:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **IOS:** I have run the respective client and confirmed it behaves correctly against the server
  - [ ] **End-to-end:** For user-facing features, I have tested the full flow from the UI (or client) through the API to the database and back
  - [ ] **N/A** — my change does not affect runtime behavior (e.g., docs-only, refactoring with existing test coverage)
Detect when Sentry/Glitchtip envelope requests are blocked by a content
blocker (vs the network being down) and surface a modal asking the user to
disable their blocker. The probe mirrors the real envelope request (POST +
sentry_key query) so blocker filter lists match it identically; a control
probe to /api/q/health distinguishes "blocked" from "offline".

The user can keep their blocker (persisted to localStorage, never prompted
again) or click "I disabled it" to re-probe and confirm.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>